### PR TITLE
Add prod-hide-percent as advanced feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 ## Unreleased
 
+### Added
+
+- `prod-hide-percent`: New feature. Hides percent value from production lines.
+
 ### Fixed
 
 - Fix duplication of Materials in Transit asset value in Long-Term Materials Receivable
-- `prod-hide-percent`: New feature. Hides percent value from production lines.
 
 ## 25.2.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 
 - Fix duplication of Materials in Transit asset value in Long-Term Materials Receivable
+- `prod-hide-percent`: New feature. Hides percent value from production lines.
 
 ## 25.2.11
 

--- a/src/features/advanced/index.ts
+++ b/src/features/advanced/index.ts
@@ -23,4 +23,5 @@ import './lm-hide-rating';
 import './mat-clean-info';
 import './minimize-headers/minimize-headers';
 import './nots-clean-notifications';
+import './prod-hide-percent';
 import './shpf-hide-sort-options';

--- a/src/features/advanced/prod-hide-percent.ts
+++ b/src/features/advanced/prod-hide-percent.ts
@@ -1,0 +1,12 @@
+import css from '@src/utils/css-utils.module.css';
+import { applyClassCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
+
+function init() {
+  applyClassCssRule(C.OrderStatus.inProgress, css.hidden);
+}
+
+features.add(
+  import.meta.url,
+  init,
+  'Hides percent value in PROD orders list',
+);

--- a/src/features/advanced/prod-hide-percent.ts
+++ b/src/features/advanced/prod-hide-percent.ts
@@ -2,11 +2,11 @@ import css from '@src/utils/css-utils.module.css';
 import { applyClassCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 
 function init() {
-  applyClassCssRule(C.OrderStatus.inProgress, css.hidden);
+  applyScopedClassCssRule('PROD', C.OrderStatus.inProgress, css.hidden);
 }
 
 features.add(
   import.meta.url,
   init,
-  'Hides percent value in PROD orders list',
+  'PROD: Hides percent value in the order list.',
 );

--- a/src/features/advanced/prod-hide-percent.ts
+++ b/src/features/advanced/prod-hide-percent.ts
@@ -1,5 +1,5 @@
 import css from '@src/utils/css-utils.module.css';
-import { applyClassCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
+import { applyScopedClassCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 
 function init() {
   applyScopedClassCssRule('PROD', C.OrderStatus.inProgress, css.hidden);


### PR DESCRIPTION
Hide css for the percent value in PROD buffer. The result slims down the PROD buffer and is easier on the eyes.

Before and after images of the feature:
![before_prod_hide_percent](https://github.com/user-attachments/assets/5accb215-ec56-4765-b2ec-ed99750ce0cd)
![after_prod_hide_percent](https://github.com/user-attachments/assets/d82f5928-9922-45e4-baf3-5478805865d1)
