### PR TITLE
Fix Production line queue time is calculated incorrectly (2nd try)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 
 - Fix duplication of Materials in Transit asset value in Long-Term Materials Receivable
+- `prod-order-eta`: Fix completion time being calculated incorrectly
 
 ## 25.2.11
 

--- a/src/features/basic/prod-order-eta.ts
+++ b/src/features/basic/prod-order-eta.ts
@@ -66,6 +66,7 @@ function calcCompletionDate(line: PrunApi.ProductionLine, order: PrunApi.Product
       queue.push(Date.now() + lineOrder.duration.millis);
     } else {
       // Order has not started
+      queue.sort()
       queue.push(queue.shift()! + lineOrder.duration.millis);
     }
     if (lineOrder === order) {


### PR DESCRIPTION
Fixes #43

The issue is line 69:
queue.shift()! is getting the first completion timestamp inside the queue variable. This array is not sorted properly to be able to get the recipe that will complete _**first**_ and is instead getting timestamps closer to the end of the currently producing recipes.
https://github.com/refined-prun/refined-prun/blob/bf18dcba9f0178808732a98da02ca6ee9c29957c/src/features/basic/prod-order-eta.ts#L57-L74

Adding `queue.sort()` before line 69 `queue.push(queue.shift()! + lineOrder.duration.millis); ` fixes the issue.
This ensures that the value returned from queue.shift()! is the first recipe to complete. In addition, because the `queue` adds queued recipes, it ensures that all subsequent queued recipes completion times are calculated correctly.

Picture 1 just to show completion times of the first few recipes currently producing.
Picture 2 shows proper completion times for BEA recipes after `queue.sort()` was put in:

<details>

![Image](https://github.com/user-attachments/assets/6ca33f22-8d96-464f-b0e2-0be4f9be46ed)

![Image](https://github.com/user-attachments/assets/4ff4e1dc-b701-4ff7-bd44-7ab420f93e81)
</details>

(First PR, I might make mistakes with it lol)