### PR TITLE
New feature context-controls-no-hover stops those command boxes at the top from expanding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- `context-controls-no-hover`: New feature. Prevents the context controls from displaying description while hovering over
 - `prod-hide-percent`: New feature. Hides percent value from production lines.
 
 ### Fixed

--- a/src/features/advanced/context-controls-no-hover.module.css
+++ b/src/features/advanced/context-controls-no-hover.module.css
@@ -1,0 +1,3 @@
+.stopDisplay {
+  display: none;
+}

--- a/src/features/advanced/context-controls-no-hover.ts
+++ b/src/features/advanced/context-controls-no-hover.ts
@@ -1,0 +1,15 @@
+import classes from './context-controls-no-hover.module.css';
+import { applyClassCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
+
+function init() {
+  applyClassCssRule(
+    `${C.ContextControls.item}:hover .${C.ContextControls.label}`,
+    classes.stopDisplay,
+  );
+}
+
+features.add(
+  import.meta.url,
+  init,
+  'Prevents the context controls from displaying description while hovering over.',
+);

--- a/src/features/advanced/index.ts
+++ b/src/features/advanced/index.ts
@@ -4,6 +4,7 @@ import './bbl-collapsible-categories';
 import './bbl-hide-book-value';
 import './bs-hide-zero-workforce';
 import './cogcpex-clean-labels';
+import './context-controls-no-hover';
 import './cxos-hide-exchange';
 import './cxpo-shorten-fields';
 import './finla-hide-ecd';


### PR DESCRIPTION
Those little command boxes at the top of buffers like PLI or BS or several others expand to show a short description. When hovering through the commands, this makes it difficult to actually click the one you want because the others expanded. Not to mention, sometimes this description text will overflow to another line and expand in an even uglier way.

This pr just adds a feature to stop them from expanding. Now hovering over these command boxes will be seamless and makes them easily clickable without hassle.