### PR TITLE
fix lint for prod-hide-percent and prod-order-eta

### DIFF
--- a/src/features/advanced/prod-hide-percent.ts
+++ b/src/features/advanced/prod-hide-percent.ts
@@ -5,8 +5,4 @@ function init() {
   applyScopedClassCssRule('PROD', C.OrderStatus.inProgress, css.hidden);
 }
 
-features.add(
-  import.meta.url,
-  init,
-  'PROD: Hides percent value in the order list.',
-);
+features.add(import.meta.url, init, 'PROD: Hides percent value in the order list.');

--- a/src/features/basic/prod-order-eta.ts
+++ b/src/features/basic/prod-order-eta.ts
@@ -66,7 +66,7 @@ function calcCompletionDate(line: PrunApi.ProductionLine, order: PrunApi.Product
       queue.push(Date.now() + lineOrder.duration.millis);
     } else {
       // Order has not started
-      queue.sort()
+      queue.sort();
       queue.push(queue.shift()! + lineOrder.duration.millis);
     }
     if (lineOrder === order) {


### PR DESCRIPTION
Github has "Unchanged files with check annotations" with these two linting warnings under changed commits. This pr simply fixes those warnings.