### PR TITLE
Quick fix to inv-compress-inventory-info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Fixed
+
+- `inv-compress-inventory-info`: Fix overlapping text and displays inventory location link
+
 ## 25.2.25
 
 ### Added

--- a/src/features/advanced/inv-compress-inventory-info.module.css
+++ b/src/features/advanced/inv-compress-inventory-info.module.css
@@ -1,14 +1,15 @@
-.sortControls {
-  padding-top: 2px;
-  padding-bottom: 2px;
+.progressBarContainer {
+  display: contents;
 }
 
-.storeInfoColumn {
+.storeViewCapacity {
+  display: flow-root;
+}
+
+.storeViewColumn {
   flex-direction: row;
 }
 
-.storeInfo {
-  position: absolute;
-  top: -16px;
-  left: -2px;
+.storeViewContainer {
+  padding-top: 0;
 }

--- a/src/features/advanced/inv-compress-inventory-info.ts
+++ b/src/features/advanced/inv-compress-inventory-info.ts
@@ -1,74 +1,11 @@
-import {
-  applyScopedClassCssRule,
-  applyScopedCssRule,
-} from '@src/infrastructure/prun-ui/refined-prun-css';
+import { applyScopedClassCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 import classes from './inv-compress-inventory-info.module.css';
-import css from '@src/utils/css-utils.module.css';
-import ContextControls from '@src/components/ContextControls.vue';
-import { getInvStore } from '@src/core/store-id';
-import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
-import {
-  getEntityNaturalIdFromAddress,
-  getLocationLineFromAddress,
-} from '@src/infrastructure/prun-api/data/addresses';
-import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
-import { shipsStore } from '@src/infrastructure/prun-api/data/ships';
-
-async function onTileReady(tile: PrunTile) {
-  await $(tile.anchor, C.StoreView.container);
-  createFragmentApp(ContextControls, {
-    items: [{ cmd: getContextCommand(tile.parameter!) }],
-  }).before(tile.anchor.parentElement!);
-}
-
-function getContextCommand(invParameter: string) {
-  const store = getInvStore(invParameter);
-  switch (store?.type) {
-    case 'STORE': {
-      const site = sitesStore.getById(store?.addressableId);
-      const naturalId = getEntityNaturalIdFromAddress(site?.address);
-      if (naturalId) {
-        return `PLI ${naturalId}`;
-      }
-      break;
-    }
-    case 'WAREHOUSE_STORE': {
-      const warehouse = warehousesStore.getById(store?.addressableId);
-      const naturalId = getEntityNaturalIdFromAddress(warehouse?.address);
-      if (!naturalId) {
-        break;
-      }
-      const location = getLocationLineFromAddress(warehouse?.address);
-      if (location?.type === 'PLANET') {
-        return `PLI ${naturalId}`;
-      }
-      if (location?.type === 'STATION') {
-        return `STNS ${naturalId}`;
-      }
-      break;
-    }
-    case 'SHIP_STORE': {
-      const ship = shipsStore.getById(store?.addressableId);
-      const registration = ship?.registration;
-      if (registration) {
-        return `SHP ${registration}`;
-      }
-      break;
-    }
-  }
-  return 'INV';
-}
 
 function init() {
-  applyScopedClassCssRule('INV', C.StoreView.row, classes.storeInfo);
-  applyScopedClassCssRule('INV', C.StoreView.column, classes.storeInfoColumn);
-  applyScopedCssRule(
-    'INV',
-    `.${C.StoreView.column} .${C.StoreView.capacity}:nth-child(1)`,
-    css.hidden,
-  );
-  applyScopedClassCssRule('INV', C.InventorySortControls.controls, classes.sortControls);
-  tiles.observe('INV', onTileReady);
+  applyScopedClassCssRule('INV', C.StoreView.column, classes.storeViewColumn);
+  applyScopedClassCssRule('INV', C.StoreView.container, classes.storeViewContainer);
+  applyScopedClassCssRule('INV', C.StoreView.capacity, classes.storeViewCapacity);
+  applyScopedClassCssRule('INV', C.ProgressBar.container, classes.progressBarContainer);
 }
 
 features.add(import.meta.url, init, 'INV: Compresses specific inventory info into a row.');


### PR DESCRIPTION
Fixes #57

This PR gives simple rules to the inv-compress-inventory-info feature and addresses concerns about the missing inventory location link and overlapping text. I'm not sure if you'd be interested in a quick release to alleviate user concerns about the feature.

I'm thinking the context controls could be added in the inventory to a separate feature with many more useful buttons rather than in this feature. 