### PR TITLE
Fixes incorrect bolding of command arguments in controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Fixed
+
+- Fixed incorrect bolding of command arguments in controls
+
 ## 25.2.27
 
 ### Fixed

--- a/src/components/ContextControlsItem.vue
+++ b/src/components/ContextControlsItem.vue
@@ -3,9 +3,9 @@ import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
 
 const props = defineProps<{ cmd: string; label?: string }>();
 
-const lastSpaceIndex = props.cmd.lastIndexOf(' ');
-const command = props.cmd.substring(0, lastSpaceIndex);
-const argument = props.cmd.substring(lastSpaceIndex + 1);
+const index = props.cmd.lastIndexOf(' ');
+const [command, argument] =
+  index > -1 ? [props.cmd.substring(0, index), props.cmd.substring(index + 1)] : [props.cmd, ''];
 
 const itemClasses = [C.ContextControls.item, C.fonts.fontRegular, C.type.typeSmall];
 </script>

--- a/src/components/ContextControlsItem.vue
+++ b/src/components/ContextControlsItem.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
 import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
 
-defineProps<{ cmd: string; label?: string }>();
+const props = defineProps<{ cmd: string; label?: string }>();
+
+const lastSpaceIndex = props.cmd.lastIndexOf(' ');
+const command = props.cmd.substring(0, lastSpaceIndex);
+const argument = props.cmd.substring(lastSpaceIndex + 1);
 
 const itemClasses = [C.ContextControls.item, C.fonts.fontRegular, C.type.typeSmall];
 </script>
@@ -10,7 +14,8 @@ const itemClasses = [C.ContextControls.item, C.fonts.fontRegular, C.type.typeSma
   <!-- The node structure is fully replicated from PrUn, don't mind unnecessary nodes. -->
   <div :class="itemClasses" @click="() => showBuffer(cmd)">
     <span>
-      <span :class="C.ContextControls.cmd">{{ cmd }}</span>
+      <span :class="C.ContextControls.cmd">{{ command }}</span>
+      {{ argument }}
     </span>
     <span v-if="label" :class="C.ContextControls.label">: {{ label }}</span>
   </div>


### PR DESCRIPTION
`ContextControlsItem.vue` has a slightly different structure from how prosperous universe displays context controls. 
Context controls in HTML from prosperous universe follow this structure:
`<span><span class="ContextControls__cmd___BXQDTL_">SYSI</span> VH-331</span>`

Context controls from the current `ContextControlsItem.vue` are in a different structure:
https://github.com/refined-prun/refined-prun/blob/6395df80e79079bf76eef815ca444f9e696c27ab/src/components/ContextControlsItem.vue#L12-L14

The command as well as the arguments are placed into the `cmd` variable and then into the span with the `C.ContextControls.cmd` which bolds all the text inside. This PR splits the argument from the command and places the argument outside this span.

The tests I did to make sure this worked as intended:
1. cmd='INV' -> command='INV', argument=''
2. cmd='INV 29927187' -> command='INV', argument='29927187'
3. cmd='XIT BURN VH-331a' -> command ='XIT BURN', argument = 'VH-331a'

As such, it basically takes the last string with no spaces and makes that the argument. if there is no argument in cmd, the string goes into command.

I figured modifying this file was easier than going through all the files that make a ContextControlsItem container and changing up all the functions to provide a command and argument separately.