### PR TITLE
Vertical scroll bar gutter in PROD is always visible (prun bug)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixed
 
-- `prun-bugs`: Fix scroll bar gutter in `PROD` taking up space without a scroll bar present
+- `prun-bugs`: Fix scrollbar gutter in `PROD` taking up space without a scrollbar present
 
 ## 25.3.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Fixed
+
+- `prun-bugs`: Fix scroll bar gutter in `PROD` taking up space without a scroll bar present
+
 ## 25.3.8
 
 ### Added

--- a/src/features/basic/prun-bugs.module.css
+++ b/src/features/basic/prun-bugs.module.css
@@ -24,3 +24,7 @@
 .disablePointerEvents {
   pointer-events: none;
 }
+
+.containerSidebarGutter {
+  scrollbar-gutter: auto;
+}

--- a/src/features/basic/prun-bugs.module.css
+++ b/src/features/basic/prun-bugs.module.css
@@ -25,6 +25,6 @@
   pointer-events: none;
 }
 
-.containerSidebarGutter {
+.containerScrollbarGutter {
   scrollbar-gutter: auto;
 }

--- a/src/features/basic/prun-bugs.ts
+++ b/src/features/basic/prun-bugs.ts
@@ -68,7 +68,11 @@ function init() {
   applyScopedClassCssRule(['PROD', 'PRODQ'], C.OrderTile.overlay, classes.disablePointerEvents);
 
   // Prevent PROD buffer vertical scroll bar gutter from being always visible
-  applyScopedClassCssRule('PROD', C.SiteProductionLines.container, classes.containerSidebarGutter);
+  applyScopedClassCssRule(
+    'PROD',
+    C.SiteProductionLines.container,
+    classes.containerScrollbarGutter,
+  );
 }
 
 features.add(import.meta.url, init, 'Fixes PrUn bugs.');

--- a/src/features/basic/prun-bugs.ts
+++ b/src/features/basic/prun-bugs.ts
@@ -1,11 +1,11 @@
+import { getPrunCssStylesheets } from '@src/infrastructure/prun-ui/prun-css';
 import {
   applyClassCssRule,
   applyCssRule,
   applyScopedClassCssRule,
 } from '@src/infrastructure/prun-ui/refined-prun-css';
-import classes from './prun-bugs.module.css';
-import { getPrunCssStylesheets } from '@src/infrastructure/prun-ui/prun-css';
 import { changeInputValue } from '@src/util';
+import classes from './prun-bugs.module.css';
 
 function removeMobileCssRules() {
   const styles = getPrunCssStylesheets();
@@ -66,6 +66,9 @@ function init() {
 
   // The overlay stops materials from being clickable
   applyScopedClassCssRule(['PROD', 'PRODQ'], C.OrderTile.overlay, classes.disablePointerEvents);
+
+  // Prevent PROD buffer vertical scroll bar gutter from being always visible
+  applyScopedClassCssRule('PROD', C.SiteProductionLines.container, classes.containerSidebarGutter);
 }
 
 features.add(import.meta.url, init, 'Fixes PrUn bugs.');


### PR DESCRIPTION
The `PROD` buffer has a scroll bar different from all other scroll bars on other buffers because it isn't setup properly on prun's side. I made a post on the forum about it for more info: [bugs-and-improvements](https://com.prosperousuniverse.com/t/bugs-and-improvements/151/1309).

The large `PROD` scroll bar gutter is like 30ish pixels wide which is annoying, not to mention all the other prun scroll bars which always take up 6 pixels whether they exist or not. This PR simply trims down the browser-placed scroll bar gutter if the tile doesn't need a scroll bar, else it does nothing. The prun scroll bars are all updated programmatically and so can't really be fixed here.

Before/after:
<details>

![Capture34](https://github.com/user-attachments/assets/24781b3b-6cbb-4d0c-a602-6a9830651d3f)
![Capture34](https://github.com/user-attachments/assets/2842d7ec-35f3-4d2f-a325-f1473dd956eb)

</details>