### PR TITLE
Add context items to match the parameters when using 'XIT REP'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Changed
+
+- `XIT REP`: Use planet id in `BRA` context button
+
 ### Fixed
 
 - `XIT GIF`: Fix borked gifs

--- a/src/features/XIT/REP/REP.ts
+++ b/src/features/XIT/REP/REP.ts
@@ -7,15 +7,13 @@ xit.add({
   name: 'REPAIRS',
   description: 'Shows the materials to repair buildings.',
   optionalParameters: 'Planet Identifier(s)',
-  contextItems: (parameters: string[]) => {
+  contextItems: parameters => {
     const cmds = [{ cmd: 'BRA' }];
-    //sites will return [] if there are no parameters other than the command
-    //All other parameters will make a context item and add it
-    const sites = computed(() => getParameterSites(parameters));
-    if (!sites || !sites.value) return cmds;
-    sites.value.forEach(site => {
+    // Sites will never be given empty parameter, which makes it always defined.
+    const sites = getParameterSites(parameters)!;
+    for (const site of sites) {
       cmds.push({ cmd: `BRA ${getEntityNaturalIdFromAddress(site.address)}` });
-    });
+    }
     return cmds;
   },
   component: () => REP,

--- a/src/features/XIT/REP/REP.ts
+++ b/src/features/XIT/REP/REP.ts
@@ -1,10 +1,22 @@
 import REP from '@src/features/XIT/REP/REP.vue';
+import { getEntityNaturalIdFromAddress } from '@src/infrastructure/prun-api/data/addresses';
+import { getParameterSites } from './entries';
 
 xit.add({
   command: ['REP', 'REPAIR', 'REPAIRS'],
   name: 'REPAIRS',
   description: 'Shows the materials to repair buildings.',
   optionalParameters: 'Planet Identifier(s)',
-  contextItems: () => [{ cmd: 'BRA' }],
+  contextItems: (parameters: string[]) => {
+    const cmds = [{ cmd: 'BRA' }];
+    //sites will return [] if there are no parameters other than the command
+    //All other parameters will make a context item and add it
+    const sites = computed(() => getParameterSites(parameters));
+    if (!sites || !sites.value) return cmds;
+    sites.value.forEach(site => {
+      cmds.push({ cmd: `BRA ${getEntityNaturalIdFromAddress(site.address)}` });
+    });
+    return cmds;
+  },
   component: () => REP,
 });

--- a/src/features/XIT/REP/REP.ts
+++ b/src/features/XIT/REP/REP.ts
@@ -8,13 +8,11 @@ xit.add({
   description: 'Shows the materials to repair buildings.',
   optionalParameters: 'Planet Identifier(s)',
   contextItems: parameters => {
-    const cmds = [{ cmd: 'BRA' }];
-    // Sites will never be given empty parameter, which makes it always defined.
-    const sites = getParameterSites(parameters)!;
-    for (const site of sites) {
-      cmds.push({ cmd: `BRA ${getEntityNaturalIdFromAddress(site.address)}` });
+    if (parameters.length === 0) {
+      return [{ cmd: 'BRA' }];
     }
-    return cmds;
+    const sites = getParameterSites(parameters) ?? [];
+    return sites.map(x => ({ cmd: `BRA ${getEntityNaturalIdFromAddress(x.address)}` }));
   },
   component: () => REP,
 });


### PR DESCRIPTION
Fixes #64

This feature adds context items as described in the above issue. If there are no valid [planet_id] parameters, `XIT REP` will show only `BRA`. If the command is `XIT REP VH-331a`, it will shpw: `BRA VH-331a`. Any number of valid [planet_id] parameters can be passed in and you will get context items for them. Passing in sites you don't own does nothing.

![Capture34](https://github.com/user-attachments/assets/0c2e010e-e41e-4314-a706-a1fb0533de7d)


