### PR TITLE
Remove `@root/` pattern in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,8 +21,7 @@
     "types": ["vite/client", "node"],
     "paths": {
       "@src/*": ["src/*"],
-      "~/*": ["src/assets/*"],
-      "@root/*": ["./*"]
+      "~/*": ["src/assets/*"]
     },
     "lib": [
       "DOM",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,8 +20,8 @@
     "verbatimModuleSyntax": false,
     "types": ["vite/client", "node"],
     "paths": {
-      "@src/*": ["./*"],
-      "~/*": ["./assets/*"]
+      "@src/*": ["./src/*"],
+      "~/*": ["./src/assets/*"]
     },
     "lib": [
       "DOM",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,8 +20,9 @@
     "verbatimModuleSyntax": false,
     "types": ["vite/client", "node"],
     "paths": {
-      "@src/*": ["./src/*"],
-      "~/*": ["./src/assets/*"]
+      "@src/*": ["src/*"],
+      "~/*": ["src/assets/*"],
+      "@root/*": ["./*"]
     },
     "lib": [
       "DOM",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,9 +20,8 @@
     "verbatimModuleSyntax": false,
     "types": ["vite/client", "node"],
     "paths": {
-      "@root/*": ["./*"],
-      "@src/*": ["src/*"],
-      "~/*": ["src/assets/*"]
+      "@src/*": ["./*"],
+      "~/*": ["./assets/*"]
     },
     "lib": [
       "DOM",


### PR DESCRIPTION
The `"@root/*": ["./*"],` line in `tsconfig.json` matches when my vscode tries to make an import. It never gets to the actual path it should be using which is `"@src/*": ["./src/*"],`.

My import turns out differently since the `"@root/*"` path matches first. the second way, and what this PR does, makes it work as intended:

`"@root/*": ["./*"],` yields `'import { keepLast } from '@root/src/utils/keep-last';'`
It's annoying to change it manually to `@src/..`, and this sometimes gives me the error `Cannot find module '@root/src/utils/keep-last' or its corresponding type declarations.`

`"@src/*": ["./src/*"],` yields ``'import { keepLast } from '@src/utils/keep-last';'``
The above works, and the import is successful

I also couldn't find any instances of `"@root/*"`, so maybe it was old and can be removed anyway. Alternatively, if `@root` is placed at the bottom, it won't be selected first when looking for a file in `src`, and `@root` will still work.

https://github.com/refined-prun/refined-prun/blob/79bb31d86c03dfcf48af6316e7dc2870de61e9dd/tsconfig.json#L22-L26