### PR TITLE
Feature progress-bar-tooltips

### DIFF
--- a/src/features/basic/index.ts
+++ b/src/features/basic/index.ts
@@ -45,6 +45,7 @@ import './prevent-delete-button-misclicks';
 import './prod-burn-link';
 import './prod-order-eta';
 import './prodq-queue-load';
+import './progress-bar-tooltips';
 import './prun-bugs';
 import './rprun-version-label';
 import './screen-tab-bar/screen-tab-bar';

--- a/src/features/basic/progress-bar-tooltips.module.css
+++ b/src/features/basic/progress-bar-tooltips.module.css
@@ -1,3 +1,0 @@
-.progressBarPrimary {
-  pointer-events: none;
-}

--- a/src/features/basic/progress-bar-tooltips.module.css
+++ b/src/features/basic/progress-bar-tooltips.module.css
@@ -1,0 +1,3 @@
+.progressBarPrimary {
+  pointer-events: none;
+}

--- a/src/features/basic/progress-bar-tooltips.ts
+++ b/src/features/basic/progress-bar-tooltips.ts
@@ -1,0 +1,68 @@
+import { applyClassCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
+import { percent2 } from '@src/utils/format';
+import { refAttributeValue } from '@src/utils/reactive-dom';
+import classes from './progress-bar-tooltips.module.css';
+import { watchEffectWhileNodeAlive } from '@src/utils/watch';
+
+function init() {
+  applyClassCssRule(C.ProgressBar.primary, classes.progressBarPrimary);
+
+  subscribe($$(document, C.ProgressBar.container), progressBar => {
+    // FLT has primary bar and secondary bar.
+    const primary = _$(progressBar, C.ProgressBar.progress)!;
+    const value = refAttributeValue(primary, 'value');
+    const max = refAttributeValue(primary, 'max');
+    progressBar.title = percent2(Number(value.value) / Number(max.value));
+
+    watchEffectWhileNodeAlive(progressBar, () => {
+      progressBar.title = percent2(Number(value.value) / Number(max.value));
+    });
+  });
+
+  subscribe($$(document, C.FactorBar.container), factorBar => {
+    // Like fertility of planets, can be positive or negative.
+    const left = _$(factorBar, C.FactorBar.left)!.children[0];
+    const right = _$(factorBar, C.FactorBar.right)!.children[0];
+    const valueLeft = refAttributeValue(left, 'value');
+    const valueRight = refAttributeValue(right, 'value');
+    factorBar.title =
+      Number(valueLeft.value) === 0
+        ? percent2(Number(valueRight.value))
+        : percent2(-Number(valueLeft.value));
+
+    watchEffectWhileNodeAlive(factorBar, () => {
+      factorBar.title =
+        Number(valueLeft.value) === 0
+          ? percent2(Number(valueRight.value))
+          : percent2(-Number(valueLeft.value));
+    });
+  });
+
+  subscribe($$(document, C.SliderView.container), container => {
+    const handle = _$(container, 'rc-slider-handle')!;
+    const value = refAttributeValue(handle, 'aria-valuenow');
+    // Differentiate between sliders from 0-1 and 1-X.
+    const max = handle.getAttribute('aria-valuemax');
+    container.title =
+      max === '1' ? percent2(Number(value.value)) : percent2(Number(value.value) / Number(max));
+    watchEffectWhileNodeAlive(container, () => {
+      container.title =
+        max === '1' ? percent2(Number(value.value)) : percent2(Number(value.value) / Number(max));
+    });
+  });
+
+  subscribe($$(document, C.OrderSlot.container), container => {
+    const progress = _$(container, C.OrderSlot.progress);
+    // Queued orders do not have a progress element.
+    if (!progress) {
+      return;
+    }
+    const value = refAttributeValue(progress, 'style');
+    container.title = percent2(parseFloat(value.value?.replace(/[^0-9.]/g, '') ?? '') / 100);
+    watchEffectWhileNodeAlive(progress, () => {
+      container.title = percent2(parseFloat(value.value?.replace(/[^0-9.]/g, '') ?? '') / 100);
+    });
+  });
+}
+
+features.add(import.meta.url, init, 'Adds tooltips to all progress bars');

--- a/src/features/basic/progress-bar-tooltips.ts
+++ b/src/features/basic/progress-bar-tooltips.ts
@@ -1,12 +1,8 @@
-import { applyClassCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 import { percent2 } from '@src/utils/format';
 import { refAttributeValue } from '@src/utils/reactive-dom';
-import classes from './progress-bar-tooltips.module.css';
 import { watchEffectWhileNodeAlive } from '@src/utils/watch';
 
 function init() {
-  applyClassCssRule(C.ProgressBar.primary, classes.progressBarPrimary);
-
   subscribe($$(document, C.ProgressBar.container), progressBar => {
     // FLT has primary bar and secondary bar.
     const primary = _$(progressBar, C.ProgressBar.progress)!;


### PR DESCRIPTION
Someone in global chat had the idea that it would be nice to have tooltips on the progress bars. A tooltip helps compare planets resources in `PLI` or `SYSI`. This PR simply adds the title attribute where necessary with reactive components to whatever the value is behind the scene. I just went ahead and made tooltips for the following:

1. Progress bars (like `SYSI`)
2. Factor bars (like `PLI` soil fertility)
3. Sliders (like `SFC` or `PRODCO`)
4. Orders (like `PROD`)

The environment bars in `PLI` are excluded, they aren't really a progress bar and mainly are just there for show. You really only care about them if they are in the green or in the red.

I considered putting a tiny xx% inside the progress bars but it needs like 8px font (maybe 9px) which is getting too small and its squished in there. Also coloring the text to make it contrast what color its on top of would be a hassle and probably not even look good.