### PR TITLE
Fix for edge case in `prodq-order-eta`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 
+- `prodq-order-eta`: Fix
 - `table-rows-alternating-colors`: Fix a rendering issue in Firefox
 
 ## 25.3.24

--- a/src/features/basic/prodq-order-eta.ts
+++ b/src/features/basic/prodq-order-eta.ts
@@ -11,16 +11,16 @@ import { calcCompletionDate } from '@src/core/production-line';
 function onTileReady(tile: PrunTile) {
   subscribe($$(tile.anchor, C.ProductionQueue.table), table => {
     subscribe($$(table, 'tr'), order => {
-      const orderId = refPrunId(order);
-      if (!orderId.value) {
+      if (_$(order, 'th')) {
         return;
       }
-      onOrderSlotReady(order.children[5] as HTMLElement, orderId, tile.parameter!);
+      onOrderSlotReady(order.children[5] as HTMLElement, order, tile.parameter!);
     });
   });
 }
 
-function onOrderSlotReady(slot: HTMLElement, orderId: Ref<string | null>, siteId: string) {
+function onOrderSlotReady(slot: HTMLElement, order: HTMLElement, siteId: string) {
+  const orderId = refPrunId(order);
   const completion = computed(() => {
     const line = productionStore.getById(siteId);
     for (const order of line?.orders ?? []) {


### PR DESCRIPTION
When the prodq window opens and there are empty slots, they don't immediately have a `prunId` when the rows load. This means that this code below wasn't assigning those rows an ETA div, and when a new order came in, it isn't getting an ETA div. This `!orderId.value` check was meant to weed out the header rows, but its weeding out order rows too. This PR fixes it with the `th` check, and it assigns all rows besides headers an ETA div. I don't have any other decent ideas for a fix besides this.

https://github.com/refined-prun/refined-prun/blob/aa99fb05561e5944c45bd86518d015b61e64355b/src/features/basic/prodq-order-eta.ts#L11-L19

Problem pictures:
<details>

![Capture](https://github.com/user-attachments/assets/fc83aaef-3190-4595-9686-e64389e49ce0)
![Capture2](https://github.com/user-attachments/assets/b23e71f2-2b57-4cae-a04b-607c21e341c4)

</details>