### PR TITLE
Add vite temporary file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 .DS_Store
 .idea
 **/.turbo
+vite.config.mts.timestamp-*.mjs


### PR DESCRIPTION
The vite temporary file sometimes ends up in my commits which is mildly annoying. This PR adds the temporary file to gitignore so I can be forever sure I'll never have to look at it again.