### PR TITLE
Standardization of CSS usage

### DIFF
--- a/docs/contributing/working-with-css.md
+++ b/docs/contributing/working-with-css.md
@@ -1,0 +1,287 @@
+# Working with CSS
+
+When working with CSS in Refined PrUn, it's often to modify or extend the base
+game's styles.
+
+For example, the APEX logo in the base game has this CSS rule:
+
+```css
+.Frame__logo___qu6xPzo {
+  margin: 13px 11px;
+  height: 30px;
+  width: 30px;
+  background-image: url(https://apex.prosperousuniverse.com/assets/images/9320395831f78bc6.png);
+  -webkit-background-size: cover;
+  background-size: cover;
+}
+```
+
+Suppose we want to create a new feature, `clickable-apex-logo`, to make the logo
+clickable. For proper user feedback, we also want the cursor to change to a
+pointer on hover. The desired CSS rule would look like this:
+
+```css
+.Frame__logo___qu6xPzo {
+  cursor: pointer;
+}
+```
+
+The simplest solution would be to add this rule directly to the extension's main
+CSS stylesheet. However, that won't allow us to enable or disable the
+`clickable-apex-logo` feature dynamically. Instead, we'll programmatically add
+this rule through a TypeScript feature file.
+
+```typescript
+function init() {
+  // Implementation here
+}
+
+features.add(import.meta.url, init, 'Makes the APEX logo clickable.');
+```
+
+The recommended approach for implementing this in Refined PrUn involves the
+following:
+
+1. CSS Modules
+2. `applyCssRule` function
+3. `C` object for class management
+4. (Optional) CSS Nesting for cleaner styles
+
+By properly using these tools, the final implementation of `clickable-apex-logo`
+would look like this:
+
+`clickable-apex-logo.ts`:
+
+```typescript
+import $style from './clickable-apex-logo.module.css';
+
+function init() {
+  applyCssRule(`.${C.Frame.logo}`, $style.logo);
+}
+
+features.add(import.meta.url, init, 'Makes the APEX logo clickable.');
+```
+
+`clickable-apex-logo.module.css`:
+
+```css
+.logo {
+  cursor: pointer;
+}
+```
+
+## CSS Modules
+
+[CSS Modules](https://github.com/css-modules/css-modules) scope class names and
+animations locally by default. When a CSS Module is imported in a TypeScript
+file, it exports an object mapping local names to generated global names. This
+has several advantages:
+
+- **Local Scope Prevents Clashes:** CSS Modules use local scope to avoid style
+  conflicts across different project parts, allowing component-scoped styling.
+- **Clear Style Dependencies:** Importing styles into their respective
+  components clarifies which styles impact which areas, enhancing code
+  readability and maintenance.
+- **Solves Global Scope Problems:** CSS Modules prevent the common issue of
+  styles in one file affecting the entire project by localizing styles to
+  specific components.
+- **Boosts Reusability and Modularity:** CSS Modules allow the same class names
+  in different modules, promoting modular, reusable styling.
+
+For example, with the `clickable-apex-logo.module.css` module:
+
+```css
+.logo {
+  cursor: pointer;
+}
+```
+
+And the corresponding TypeScript:
+
+```typescript
+import $style from './clickable-apex-logo.module.css';
+
+function init() {
+  console.log($style.logo); // Outputs: "rp-clickable-apex-logo__logo___63cd318"
+}
+
+features.add(import.meta.url, init, 'Makes the APEX logo clickable.');
+```
+
+## `applyCssRule` Function
+
+With our CSS Module in place, we can use the
+`rp-clickable-apex-logo__logo___63cd318` class to apply the cursor pointer to
+the APEX logo HTML element. There are two ways to do that:
+
+1. Using MutationObserver, wait until `Frame__logo___qu6xPzo` element is added
+   to the document, and then manually add
+   `rp-clickable-apex-logo__logo___63cd318` to that new element.
+2. Take the `rp-clickable-apex-logo__logo___63cd318` rule, replace the selector
+   with `.Frame__logo___qu6xPzo` and add it to the document.
+
+The former approach is more intrusive and doesn't scale well with the amount of
+elements added to the document, so we will use the latter.
+
+The general process is:
+
+1. Get this rule:
+
+```css
+.rp-clickable-apex-logo__logo___63cd318 {
+  cursor: pointer;
+}
+```
+
+2. Modify the selector:
+
+```css
+.Frame__logo___qu6xPzo {
+  cursor: pointer;
+}
+```
+
+3. Dynamically add this rule to the game.
+
+To help with that, we have an `applyCssRule(selector, sourceClass)` function
+that does for you all the steps above. This function is globally available via
+[unimport](https://github.com/unjs/unimport), so you don't need to import
+anything in your file to use it. Here's how you can use this function in our
+example:
+
+```typescript
+import $style from './clickable-apex-logo.module.css';
+
+function init() {
+  applyCssRule('.Frame__logo___qu6xPzo', $style.logo);
+}
+
+features.add(import.meta.url, init, 'Makes the APEX logo clickable.');
+```
+
+This function accepts either a single `string` or an array of `string`
+selectors:
+
+```typescript
+// Separate calls
+applyCssRule('.ComExOrdersPanel__filter___vu7cNod', $style.filter);
+applyCssRule('.LocalMarket__filter___vANBFfG', $style.filter);
+applyCssRule('.ContractsListTable__filter___nzzypkA', $style.filter);
+
+// Combined into one
+applyCssRule(
+  [
+    '.ComExOrdersPanel__filter___vu7cNod',
+    '.LocalMarket__filter___vANBFfG',
+    '.ContractsListTable__filter___nzzypkA'
+  ],
+  $style.filter
+);
+```
+
+You can also scope CSS rules to specific commands with the overloaded version of
+`applyCssRule(command, selector, sourceClass)`:
+
+```typescript
+// Separate calls
+applyCssRule('PROD', `.OrderTile__overlay___lqLFDV_`, $style.disablePointerEvents);
+applyCssRule('PRODQ', `.OrderTile__overlay___lqLFDV_`, $style.disablePointerEvents);
+
+// Combined into one
+applyCssRule(['PROD', 'PRODQ'], `.OrderTile__overlay___lqLFDV_`, $style.disablePointerEvents);
+```
+
+## `C` Object
+
+Using raw class names like `OrderTile__overlay___lqLFDV_` can lead to errors and
+maintenance risks (e.g., if PrUn developers change hashes). The `C` object
+solves this problem. It maps all PrUn class names, allowing auto-completion and
+reducing chance of bugs.
+
+For example:
+
+```typescript
+import $style from './clickable-apex-logo.module.css';
+
+function init() {
+  // Direct use of hardcoded class
+  applyCssRule('.Frame__logo___qu6xPzo', $style.logo);
+
+  // Cleaner with `C` object
+  applyCssRule(`.${C.Frame.logo}`, $style.logo);
+}
+
+features.add(import.meta.url, init, 'Makes the APEX logo clickable.');
+```
+
+Auto-complete support from the `C` object makes it easier to avoid errors.
+
+## (Optional) CSS Nesting
+
+Suppose we want additional styles on hover, such as a tint effect. Since
+`applyCssRule` is only copying one rule at a time, you cannot just declare a
+`.logo:hover` rule:
+
+```css
+.logo {
+  cursor: pointer;
+}
+
+/* This will not work! */
+.logo:hover {
+  background-color: rgba(128, 128, 128, 0.5);
+}
+```
+
+To make it work, you need to declare a separate class and call
+`applyCssRule` for it:
+
+```css
+.logo {
+  cursor: pointer;
+}
+
+.logoHover {
+  background-color: rgba(128, 128, 128, 0.5);
+}
+```
+
+```typescript
+import $style from './clickable-apex-logo.module.css';
+
+function init() {
+  applyCssRule(`.${C.Frame.logo}`, $style.logo);
+  applyCssRule(`.${C.Frame.logo}:hover`, $style.logoHover);
+}
+
+features.add(import.meta.url, init, 'Makes the APEX logo clickable.');
+```
+
+While functional, this splits CSS logic into the TypeScript file. Instead, we
+can
+use [CSS Nesting](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_nesting/Using_CSS_nesting)
+for cleaner code:
+
+`clickable-apex-logo.module.css`:
+
+```css
+.logo {
+  cursor: pointer;
+
+  &:hover {
+    background-color: rgba(128, 128, 128, 0.5);
+  }
+}
+```
+
+This allows a single `applyCssRule` call:
+
+```typescript
+import $style from './clickable-apex-logo.module.css';
+
+function init() {
+  applyCssRule(`.${C.Frame.logo}`, $style.logo);
+}
+
+features.add(import.meta.url, init, 'Makes the APEX logo clickable.');
+```

--- a/src/components/ColoredIconDetail.vue
+++ b/src/components/ColoredIconDetail.vue
@@ -56,7 +56,7 @@ function binarySearchFontSize(span: HTMLElement, low: number, high: number, maxW
 </template>
 
 <style module>
-.detail {
+.label {
   font-size: 7px;
   white-space: nowrap;
 }

--- a/src/features/advanced/always-visible-tile-controls.ts
+++ b/src/features/advanced/always-visible-tile-controls.ts
@@ -1,9 +1,9 @@
-import classes from './always-visible-tile-controls.module.css';
+import $style from './always-visible-tile-controls.module.css';
 import css from '@src/utils/css-utils.module.css';
 
 function init() {
   applyCssRule(`.${C.TileControls.container} > .${C.TileControls.icon}`, css.hidden);
-  applyCssRule(`.${C.TileControls.container} > .${C.TileControls.controls}`, classes.show);
+  applyCssRule(`.${C.TileControls.container} > .${C.TileControls.controls}`, $style.show);
 }
 
 features.add(import.meta.url, init, 'Makes top-right tile controls always visible.');

--- a/src/features/advanced/always-visible-tile-controls.ts
+++ b/src/features/advanced/always-visible-tile-controls.ts
@@ -1,5 +1,4 @@
 import classes from './always-visible-tile-controls.module.css';
-import { applyCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 import css from '@src/utils/css-utils.module.css';
 
 function init() {

--- a/src/features/advanced/bbl-clean-repair-info.ts
+++ b/src/features/advanced/bbl-clean-repair-info.ts
@@ -1,5 +1,4 @@
 import css from '@src/utils/css-utils.module.css';
-import { applyScopedCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 import { watchEffectWhileNodeAlive } from '@src/utils/watch';
 import { refPrunId } from '@src/infrastructure/prun-ui/attributes';
 import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
@@ -33,19 +32,19 @@ function setAttribute(element: HTMLElement, attribute: string, value: boolean) {
 
 function init() {
   // Hide 'Last repair'
-  applyScopedCssRule(
+  applyCssRule(
     'BBL',
     `.${C.SectionList.section}[data-rp-established] .${C.SectionList.table} tr:nth-child(2)`,
     css.hidden,
   );
   // Hide 'Established'
-  applyScopedCssRule(
+  applyCssRule(
     'BBL',
     `.${C.SectionList.section}[data-rp-repaired] .${C.SectionList.table} tr:nth-child(1)`,
     css.hidden,
   );
   // Hide 'Repair costs'
-  applyScopedCssRule(
+  applyCssRule(
     'BBL',
     `.${C.SectionList.section}[data-rp-infrastructure] .${C.SectionList.table} tr:nth-child(3)`,
     css.hidden,

--- a/src/features/advanced/bbl-collapsible-categories.tsx
+++ b/src/features/advanced/bbl-collapsible-categories.tsx
@@ -1,5 +1,5 @@
 import css from '@src/utils/css-utils.module.css';
-import classes from './bbl-collapsible-categories.module.css';
+import $style from './bbl-collapsible-categories.module.css';
 
 function onTileReady(tile: PrunTile) {
   subscribe($$(tile.anchor, C.SectionList.container), container => {
@@ -23,7 +23,7 @@ function init() {
     `.${C.SectionList.divider}:not(:has(.${C.RadioItem.active})) + div`,
     css.hidden,
   );
-  applyCssRule('BBL', `.${C.SectionList.divider}`, classes.divider);
+  applyCssRule('BBL', `.${C.SectionList.divider}`, $style.divider);
   tiles.observe('BBL', onTileReady);
 }
 

--- a/src/features/advanced/bbl-collapsible-categories.tsx
+++ b/src/features/advanced/bbl-collapsible-categories.tsx
@@ -1,9 +1,5 @@
 import css from '@src/utils/css-utils.module.css';
 import classes from './bbl-collapsible-categories.module.css';
-import {
-  applyScopedClassCssRule,
-  applyScopedCssRule,
-} from '@src/infrastructure/prun-ui/refined-prun-css';
 
 function onTileReady(tile: PrunTile) {
   subscribe($$(tile.anchor, C.SectionList.container), container => {
@@ -22,12 +18,12 @@ function onTileReady(tile: PrunTile) {
 }
 
 function init() {
-  applyScopedCssRule(
+  applyCssRule(
     'BBL',
     `.${C.SectionList.divider}:not(:has(.${C.RadioItem.active})) + div`,
     css.hidden,
   );
-  applyScopedClassCssRule('BBL', C.SectionList.divider, classes.divider);
+  applyCssRule('BBL', `.${C.SectionList.divider}`, classes.divider);
   tiles.observe('BBL', onTileReady);
 }
 

--- a/src/features/advanced/bbl-hide-book-value.ts
+++ b/src/features/advanced/bbl-hide-book-value.ts
@@ -1,8 +1,7 @@
 import css from '@src/utils/css-utils.module.css';
-import { applyScopedCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 
 function init() {
-  applyScopedCssRule(
+  applyCssRule(
     'BBL',
     `.${C.SectionList.section} .${C.SectionList.table} tr:nth-child(5)`,
     css.hidden,

--- a/src/features/advanced/context-controls-no-hover.ts
+++ b/src/features/advanced/context-controls-no-hover.ts
@@ -1,5 +1,4 @@
 import css from '@src/utils/css-utils.module.css';
-import { applyCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 
 function init() {
   applyCssRule(`.${C.ContextControls.item}:hover .${C.ContextControls.label}`, css.hidden);

--- a/src/features/advanced/cxos-hide-exchange.ts
+++ b/src/features/advanced/cxos-hide-exchange.ts
@@ -1,8 +1,7 @@
-import { applyScopedCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 import css from '@src/utils/css-utils.module.css';
 
 function init() {
-  applyScopedCssRule('CXOS', 'tr > *:first-child', css.hidden);
+  applyCssRule('CXOS', 'tr > *:first-child', css.hidden);
 }
 
 features.add(import.meta.url, init, 'CXOS: Hides the "Exchange" column.');

--- a/src/features/advanced/flt-hide-transponder.ts
+++ b/src/features/advanced/flt-hide-transponder.ts
@@ -1,8 +1,7 @@
-import { applyScopedCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 import css from '@src/utils/css-utils.module.css';
 
 function init() {
-  applyScopedCssRule(['FLT', 'FLTS', 'FLTP'], 'tr > *:first-child', css.hidden);
+  applyCssRule(['FLT', 'FLTS', 'FLTP'], 'tr > *:first-child', css.hidden);
 }
 
 features.add(import.meta.url, init, 'FLT: Hides the "Transponder" column.');

--- a/src/features/advanced/hide-ctx-name.ts
+++ b/src/features/advanced/hide-ctx-name.ts
@@ -1,5 +1,4 @@
 import css from '@src/utils/css-utils.module.css';
-import { applyCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 
 function init() {
   // Unfortunately, there are two classes that start with 'ContextControls__container'.

--- a/src/features/advanced/hide-form-errors.ts
+++ b/src/features/advanced/hide-form-errors.ts
@@ -1,11 +1,11 @@
 import css from '@src/utils/css-utils.module.css';
-import classes from './hide-form-errors.module.css';
+import $style from './hide-form-errors.module.css';
 
 function init() {
   // Hide error messages in form components
   // Remove hard-coded ones when molp fixes class duplication
-  applyCssRule('.FormComponent__containerError___pN__L1Q', classes.containerError);
-  applyCssRule('.FormComponent__containerError___jKoukmU', classes.containerError);
+  applyCssRule('.FormComponent__containerError___pN__L1Q', $style.containerError);
+  applyCssRule('.FormComponent__containerError___jKoukmU', $style.containerError);
   applyCssRule('.FormComponent__errorMessage___mBdvpz5', css.hidden);
   applyCssRule('.FormComponent__errorMessage___R2eGj1h', css.hidden);
 }

--- a/src/features/advanced/hide-form-errors.ts
+++ b/src/features/advanced/hide-form-errors.ts
@@ -1,14 +1,13 @@
 import css from '@src/utils/css-utils.module.css';
 import classes from './hide-form-errors.module.css';
-import { applyClassCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 
 function init() {
   // Hide error messages in form components
   // Remove hard-coded ones when molp fixes class duplication
-  applyClassCssRule(C.FormComponent.containerError, classes.containerError);
-  applyClassCssRule('FormComponent__containerError___pN__L1Q', classes.containerError);
-  applyClassCssRule(C.FormComponent.errorMessage, css.hidden);
-  applyClassCssRule('FormComponent__errorMessage___mBdvpz5', css.hidden);
+  applyCssRule('.FormComponent__containerError___pN__L1Q', classes.containerError);
+  applyCssRule('.FormComponent__containerError___jKoukmU', classes.containerError);
+  applyCssRule('.FormComponent__errorMessage___mBdvpz5', css.hidden);
+  applyCssRule('.FormComponent__errorMessage___R2eGj1h', css.hidden);
 }
 
 features.add(import.meta.url, init, 'Hides error labels from form fields with incorrect input.');

--- a/src/features/advanced/hide-item-names.ts
+++ b/src/features/advanced/hide-item-names.ts
@@ -1,11 +1,10 @@
 import css from '@src/utils/css-utils.module.css';
 import classes from './hide-item-names.module.css';
-import { applyClassCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 
 function init() {
-  applyClassCssRule(C.GridItemView.name, css.hidden);
+  applyCssRule(`.${C.GridItemView.name}`, css.hidden);
   // Remove gaps between items in GridView
-  applyClassCssRule(C.GridItemView.container, classes.gridItem);
+  applyCssRule(`.${C.GridItemView.container}`, classes.gridItem);
 }
 
 features.add(

--- a/src/features/advanced/hide-item-names.ts
+++ b/src/features/advanced/hide-item-names.ts
@@ -1,10 +1,10 @@
 import css from '@src/utils/css-utils.module.css';
-import classes from './hide-item-names.module.css';
+import $style from './hide-item-names.module.css';
 
 function init() {
   applyCssRule(`.${C.GridItemView.name}`, css.hidden);
   // Remove gaps between items in GridView
-  applyCssRule(`.${C.GridItemView.container}`, classes.gridItem);
+  applyCssRule(`.${C.GridItemView.container}`, $style.gridItem);
 }
 
 features.add(

--- a/src/features/advanced/hide-system-chat-messages/SelectButton.vue
+++ b/src/features/advanced/hide-system-chat-messages/SelectButton.vue
@@ -14,7 +14,7 @@ const model = computed({
 </script>
 
 <template>
-  <div class="SelectButton__container___vjN14Xf">
+  <div :class="C.SelectButton.container">
     <RadioItem v-model="model">
       {{ label }}
     </RadioItem>

--- a/src/features/advanced/hide-system-chat-messages/hide-system-chat-messages.ts
+++ b/src/features/advanced/hide-system-chat-messages/hide-system-chat-messages.ts
@@ -1,4 +1,4 @@
-import classes from './hide-system-chat-messages.module.css';
+import $style from './hide-system-chat-messages.module.css';
 import css from '@src/utils/css-utils.module.css';
 import { watchEffectWhileNodeAlive } from '@src/utils/watch';
 import { observeDescendantListChanged } from '@src/utils/mutation-observer';
@@ -53,12 +53,12 @@ function onTileReady(tile: PrunTile) {
 
   subscribe($$(tile.anchor, C.MessageList.messages), messages => {
     watchEffectWhileNodeAlive(messages, () => {
-      messages.classList.remove(classes.hideJoined, classes.hideDeleted);
+      messages.classList.remove($style.hideJoined, $style.hideDeleted);
       if (hideJoined.value) {
-        messages.classList.add(classes.hideJoined);
+        messages.classList.add($style.hideJoined);
       }
       if (hideDeleted.value) {
-        messages.classList.add(classes.hideDeleted);
+        messages.classList.add($style.hideDeleted);
       }
     });
     subscribe($$(messages, C.Message.message), processMessage);
@@ -73,17 +73,17 @@ function processMessage(message: HTMLElement) {
       return;
     }
     if (name.children.length > 0) {
-      message.classList.add(classes.deleted);
+      message.classList.add($style.deleted);
     } else {
-      message.classList.add(classes.joined);
+      message.classList.add($style.joined);
     }
   });
 }
 
 function init() {
   tiles.observe(['COMG', 'COMP', 'COMU'], onTileReady);
-  applyCssRule(`.${classes.hideJoined} .${classes.joined}`, css.hidden);
-  applyCssRule(`.${classes.hideDeleted} .${classes.deleted}`, css.hidden);
+  applyCssRule(`.${$style.hideJoined} .${$style.joined}`, css.hidden);
+  applyCssRule(`.${$style.hideDeleted} .${$style.deleted}`, css.hidden);
 }
 
 features.add(import.meta.url, init, 'Hides system messages in chats.');

--- a/src/features/advanced/hide-system-chat-messages/hide-system-chat-messages.ts
+++ b/src/features/advanced/hide-system-chat-messages/hide-system-chat-messages.ts
@@ -1,6 +1,5 @@
 import classes from './hide-system-chat-messages.module.css';
 import css from '@src/utils/css-utils.module.css';
-import { applyCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 import { watchEffectWhileNodeAlive } from '@src/utils/watch';
 import { observeDescendantListChanged } from '@src/utils/mutation-observer';
 import SelectButton from '@src/features/advanced/hide-system-chat-messages/SelectButton.vue';

--- a/src/features/advanced/hide-weight-volume-labels.ts
+++ b/src/features/advanced/hide-weight-volume-labels.ts
@@ -1,8 +1,7 @@
 import css from '@src/utils/css-utils.module.css';
-import { applyClassCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 
 function init() {
-  applyClassCssRule(C.StoreView.name, css.hidden);
+  applyCssRule(`.${C.StoreView.name}`, css.hidden);
 }
 
 features.add(import.meta.url, init, 'Hides "Weight" and "Volume" labels in all inventories.');

--- a/src/features/advanced/lm-hide-rating.ts
+++ b/src/features/advanced/lm-hide-rating.ts
@@ -1,9 +1,9 @@
 import css from '@src/utils/css-utils.module.css';
-import classes from './lm-hide-rating.module.css';
+import $style from './lm-hide-rating.module.css';
 
 function init() {
   applyCssRule('LM', `.${C.RatingIcon.container}`, css.hidden);
-  applyCssRule('LM', `.${C.CommodityAd.text}`, classes.text);
+  applyCssRule('LM', `.${C.CommodityAd.text}`, $style.text);
 }
 
 features.add(import.meta.url, init, 'LM: Hides rating icon from ads.');

--- a/src/features/advanced/lm-hide-rating.ts
+++ b/src/features/advanced/lm-hide-rating.ts
@@ -1,10 +1,9 @@
 import css from '@src/utils/css-utils.module.css';
 import classes from './lm-hide-rating.module.css';
-import { applyScopedClassCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 
 function init() {
-  applyScopedClassCssRule('LM', C.RatingIcon.container, css.hidden);
-  applyScopedClassCssRule('LM', C.CommodityAd.text, classes.text);
+  applyCssRule('LM', `.${C.RatingIcon.container}`, css.hidden);
+  applyCssRule('LM', `.${C.CommodityAd.text}`, classes.text);
 }
 
 features.add(import.meta.url, init, 'LM: Hides rating icon from ads.');

--- a/src/features/advanced/mat-clean-info.ts
+++ b/src/features/advanced/mat-clean-info.ts
@@ -1,13 +1,12 @@
 import css from '@src/utils/css-utils.module.css';
-import { applyScopedCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 
 function init() {
-  applyScopedCssRule(
+  applyCssRule(
     'MAT',
     `.${C.MaterialInformation.container} > .${C.FormComponent.containerPassive}:nth-child(2)`,
     css.hidden,
   );
-  applyScopedCssRule(
+  applyCssRule(
     'MAT',
     `.${C.MaterialInformation.container} > .${C.FormComponent.containerPassive}:nth-child(6)`,
     css.hidden,

--- a/src/features/advanced/minimize-headers/MinimizeRow.vue
+++ b/src/features/advanced/minimize-headers/MinimizeRow.vue
@@ -32,10 +32,10 @@ const symbol = computed(() => (isMinimized ? '+' : '-'));
   cursor: pointer;
   background-color: #26353e;
   color: #3fa2de;
-}
 
-.minimize:hover {
-  color: #26353e;
-  background-color: #3fa2de;
+  &:hover {
+    color: #26353e;
+    background-color: #3fa2de;
+  }
 }
 </style>

--- a/src/features/advanced/prod-hide-percent.ts
+++ b/src/features/advanced/prod-hide-percent.ts
@@ -1,8 +1,7 @@
 import css from '@src/utils/css-utils.module.css';
-import { applyScopedClassCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 
 function init() {
-  applyScopedClassCssRule('PROD', C.OrderStatus.inProgress, css.hidden);
+  applyCssRule('PROD', `.${C.OrderStatus.inProgress}`, css.hidden);
 }
 
 features.add(import.meta.url, init, 'PROD: Hides percent value in the order list.');

--- a/src/features/advanced/prodq-hide-government-links.ts
+++ b/src/features/advanced/prodq-hide-government-links.ts
@@ -1,8 +1,7 @@
-import { applyScopedCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 import css from '@src/utils/css-utils.module.css';
 
 function init() {
-  applyScopedCssRule(
+  applyCssRule(
     'PRODQ',
     `.${C.ProductionQueue.table} tbody tr td:nth-child(3) .${C.Link.link}`,
     css.hidden,

--- a/src/features/advanced/shpf-hide-sort-options.ts
+++ b/src/features/advanced/shpf-hide-sort-options.ts
@@ -1,8 +1,7 @@
 import css from '@src/utils/css-utils.module.css';
-import { applyScopedClassCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 
 function init() {
-  applyScopedClassCssRule('SHPF', C.InventorySortControls.controls, css.hidden);
+  applyCssRule('SHPF', `.${C.InventorySortControls.controls}`, css.hidden);
 }
 
 features.add(import.meta.url, init, 'SHPF: Hides inventory sort options.');

--- a/src/features/basic/align-chat-delete-button.ts
+++ b/src/features/basic/align-chat-delete-button.ts
@@ -1,11 +1,11 @@
-import classes from './align-chat-delete-button.module.css';
+import $style from './align-chat-delete-button.module.css';
 
 function init() {
-  applyCssRule(`.${C.Message.controlsAndText}`, classes.container);
-  applyCssRule(`.${C.Message.controls}`, classes.delete);
+  applyCssRule(`.${C.Message.controlsAndText}`, $style.container);
+  applyCssRule(`.${C.Message.controls}`, $style.delete);
   applyCssRule(
     `.${C.Message.message}:has(.${C.Message.controlsAndText} .${C.Message.controls}) .${C.Sender.name}`,
-    classes.username,
+    $style.username,
   );
 }
 

--- a/src/features/basic/align-chat-delete-button.ts
+++ b/src/features/basic/align-chat-delete-button.ts
@@ -1,9 +1,8 @@
 import classes from './align-chat-delete-button.module.css';
-import { applyClassCssRule, applyCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 
 function init() {
-  applyClassCssRule(C.Message.controlsAndText, classes.container);
-  applyClassCssRule(C.Message.controls, classes.delete);
+  applyCssRule(`.${C.Message.controlsAndText}`, classes.container);
+  applyCssRule(`.${C.Message.controls}`, classes.delete);
   applyCssRule(
     `.${C.Message.message}:has(.${C.Message.controlsAndText} .${C.Message.controls}) .${C.Sender.name}`,
     classes.username,

--- a/src/features/basic/bbl-sticky-dividers.ts
+++ b/src/features/basic/bbl-sticky-dividers.ts
@@ -1,7 +1,7 @@
-import classes from './bbl-sticky-dividers.module.css';
+import $style from './bbl-sticky-dividers.module.css';
 
 function init() {
-  applyCssRule('BBL', `.${C.SectionList.divider}`, classes.divider);
+  applyCssRule('BBL', `.${C.SectionList.divider}`, $style.divider);
 }
 
 features.add(import.meta.url, init, 'BBL: Makes building category dividers sticky.');

--- a/src/features/basic/bbl-sticky-dividers.ts
+++ b/src/features/basic/bbl-sticky-dividers.ts
@@ -1,8 +1,7 @@
 import classes from './bbl-sticky-dividers.module.css';
-import { applyScopedClassCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 
 function init() {
-  applyScopedClassCssRule('BBL', C.SectionList.divider, classes.divider);
+  applyCssRule('BBL', `.${C.SectionList.divider}`, classes.divider);
 }
 
 features.add(import.meta.url, init, 'BBL: Makes building category dividers sticky.');

--- a/src/features/basic/better-item-colors.ts
+++ b/src/features/basic/better-item-colors.ts
@@ -1,5 +1,4 @@
 import classes from './better-item-colors.module.css';
-import { applyCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 import { sanitizeCategoryName } from '@src/infrastructure/prun-ui/item-tracker';
 
 function init() {

--- a/src/features/basic/better-item-colors.ts
+++ b/src/features/basic/better-item-colors.ts
@@ -1,14 +1,14 @@
-import classes from './better-item-colors.module.css';
+import $style from './better-item-colors.module.css';
 import { sanitizeCategoryName } from '@src/infrastructure/prun-ui/item-tracker';
 
 function init() {
-  applyCategoryRule('agricultural products', classes.agriculturalProducts);
-  applyCategoryRule('consumables (basic)', classes.consumablesBasic);
-  applyCategoryRule('consumables (luxury)', classes.consumablesLuxury);
-  applyCategoryRule('fuels', classes.fuels);
-  applyCategoryRule('liquids', classes.liquids);
-  applyCategoryRule('plastics', classes.plastics);
-  applyCategoryRule('ship shields', classes.shipShields);
+  applyCategoryRule('agricultural products', $style.agriculturalProducts);
+  applyCategoryRule('consumables (basic)', $style.consumablesBasic);
+  applyCategoryRule('consumables (luxury)', $style.consumablesLuxury);
+  applyCategoryRule('fuels', $style.fuels);
+  applyCategoryRule('liquids', $style.liquids);
+  applyCategoryRule('plastics', $style.plastics);
+  applyCategoryRule('ship shields', $style.shipShields);
 }
 
 function applyCategoryRule(category: string, rule: string) {

--- a/src/features/basic/bigger-item-count-font.ts
+++ b/src/features/basic/bigger-item-count-font.ts
@@ -1,8 +1,7 @@
 import classes from './bigger-item-count-font.module.css';
-import { applyClassCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 
 function init() {
-  applyClassCssRule(C.MaterialIcon.typeVerySmall, classes.indicator);
+  applyCssRule(`.${C.MaterialIcon.typeVerySmall}`, classes.indicator);
 }
 
 features.add(import.meta.url, init, 'Makes the item count label font bigger.');

--- a/src/features/basic/bigger-item-count-font.ts
+++ b/src/features/basic/bigger-item-count-font.ts
@@ -1,7 +1,7 @@
-import classes from './bigger-item-count-font.module.css';
+import $style from './bigger-item-count-font.module.css';
 
 function init() {
-  applyCssRule(`.${C.MaterialIcon.typeVerySmall}`, classes.indicator);
+  applyCssRule(`.${C.MaterialIcon.typeVerySmall}`, $style.indicator);
 }
 
 features.add(import.meta.url, init, 'Makes the item count label font bigger.');

--- a/src/features/basic/clickable-apex-logo.ts
+++ b/src/features/basic/clickable-apex-logo.ts
@@ -1,10 +1,9 @@
 import classes from './clickable-apex-logo.module.css';
 import { companyStore } from '@src/infrastructure/prun-api/data/company';
-import { applyClassCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
 
 function init() {
-  applyClassCssRule(C.Frame.logo, classes.logo);
+  applyCssRule(`.${C.Frame.logo}`, classes.logo);
   subscribe($$(document, C.Frame.logo), logo => {
     logo.addEventListener('click', () => showBuffer(`CO ${companyStore.value?.code}`));
   });

--- a/src/features/basic/clickable-apex-logo.ts
+++ b/src/features/basic/clickable-apex-logo.ts
@@ -1,9 +1,9 @@
-import classes from './clickable-apex-logo.module.css';
+import $style from './clickable-apex-logo.module.css';
 import { companyStore } from '@src/infrastructure/prun-api/data/company';
 import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
 
 function init() {
-  applyCssRule(`.${C.Frame.logo}`, classes.logo);
+  applyCssRule(`.${C.Frame.logo}`, $style.logo);
   subscribe($$(document, C.Frame.logo), logo => {
     logo.addEventListener('click', () => showBuffer(`CO ${companyStore.value?.code}`));
   });

--- a/src/features/basic/contd-upward-search-results.ts
+++ b/src/features/basic/contd-upward-search-results.ts
@@ -1,7 +1,7 @@
-import classes from './contd-upward-search-results.module.css';
+import $style from './contd-upward-search-results.module.css';
 
 function init() {
-  applyCssRule('CONTD', `.${C.UserSelector.suggestionsContainer}`, classes.suggestions);
+  applyCssRule('CONTD', `.${C.UserSelector.suggestionsContainer}`, $style.suggestions);
 }
 
 features.add(import.meta.url, init, 'CONTD: Moves the search bar results above the search bar.');

--- a/src/features/basic/contd-upward-search-results.ts
+++ b/src/features/basic/contd-upward-search-results.ts
@@ -1,8 +1,7 @@
 import classes from './contd-upward-search-results.module.css';
-import { applyScopedClassCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 
 function init() {
-  applyScopedClassCssRule('CONTD', C.UserSelector.suggestionsContainer, classes.suggestions);
+  applyCssRule('CONTD', `.${C.UserSelector.suggestionsContainer}`, classes.suggestions);
 }
 
 features.add(import.meta.url, init, 'CONTD: Moves the search bar results above the search bar.');

--- a/src/features/basic/custom-item-sorting/custom-item-sorting.ts
+++ b/src/features/basic/custom-item-sorting/custom-item-sorting.ts
@@ -1,5 +1,5 @@
 import css from '@src/utils/css-utils.module.css';
-import classes from './custom-item-sorting.module.css';
+import $style from './custom-item-sorting.module.css';
 import { BurnValues, getPlanetBurn } from '@src/core/burn';
 import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
 import CategoryHeader from './CategoryHeader.vue';
@@ -87,9 +87,9 @@ async function applyCustomSorting(tile: PrunTile, container: HTMLElement) {
 
   watchEffectWhileNodeAlive(sortOptions, () => {
     if (sortingData.active || catSort.value) {
-      sortOptions.classList.add(classes.custom);
+      sortOptions.classList.add($style.custom);
     } else {
-      sortOptions.classList.remove(classes.custom);
+      sortOptions.classList.remove($style.custom);
     }
   });
 
@@ -252,7 +252,7 @@ const burnSortingMode = {
 };
 
 function init() {
-  applyCssRule(`.${classes.custom} .${C.InventorySortControls.order} > div`, css.hidden);
+  applyCssRule(`.${$style.custom} .${C.InventorySortControls.order} > div`, css.hidden);
   tiles.observe(['INV', 'SHPI'], onTileReady);
   xit.add({
     command: 'SORT',

--- a/src/features/basic/custom-item-sorting/custom-item-sorting.ts
+++ b/src/features/basic/custom-item-sorting/custom-item-sorting.ts
@@ -8,7 +8,6 @@ import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
 import GridMaterialIcon from '@src/components/GridMaterialIcon.vue';
 import SORT from '@src/features/XIT/SORT/SORT.vue';
 import { createFragmentApp, FragmentAppScope } from '@src/utils/vue-fragment-app';
-import { applyCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
 import { sortByMaterial, sortMaterials } from '@src/core/sort-materials';
 import { watchEffectWhileNodeAlive } from '@src/utils/watch';

--- a/src/features/basic/custom-left-sidebar/custom-left-sidebar.ts
+++ b/src/features/basic/custom-left-sidebar/custom-left-sidebar.ts
@@ -1,6 +1,5 @@
 import css from '@src/utils/css-utils.module.css';
 import SidebarButtons from './SidebarButtons.vue';
-import { applyCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 import { refAttributeValue } from '@src/utils/reactive-dom';
 
 function init() {

--- a/src/features/basic/cxpo-order-book/OrderRow.vue
+++ b/src/features/basic/cxpo-order-book/OrderRow.vue
@@ -26,7 +26,9 @@ const priceClass = computed(() =>
 /*
   Override left/right padding from vanilla class
 */
-table tbody td.price {
-  padding: 2px;
+.price {
+  table tbody td& {
+    padding: 2px;
+  }
 }
 </style>

--- a/src/features/basic/finla-more-columns.module.css
+++ b/src/features/basic/finla-more-columns.module.css
@@ -1,7 +1,9 @@
-.firstColumn {
-  width: 1%;
-}
+.row {
+  td:first-child {
+    width: 1%;
+  }
 
-.otherColumns {
-  width: unset;
+  td:not(:first-child) {
+    width: unset;
+  }
 }

--- a/src/features/basic/finla-more-columns.tsx
+++ b/src/features/basic/finla-more-columns.tsx
@@ -1,4 +1,4 @@
-import classes from './finla-more-columns.module.css';
+import $style from './finla-more-columns.module.css';
 import css from '@src/utils/css-utils.module.css';
 import { refTextContent } from '@src/utils/reactive-dom';
 import { fixed0 } from '@src/utils/format';
@@ -72,7 +72,7 @@ function hiddenIfZero(total: Ref<number | undefined>) {
 }
 
 function init() {
-  applyCssRule(`.${C.LiquidAssetsPanel.row}`, classes.row);
+  applyCssRule(`.${C.LiquidAssetsPanel.row}`, $style.row);
   tiles.observe('FINLA', onTileReady);
 }
 

--- a/src/features/basic/finla-more-columns.tsx
+++ b/src/features/basic/finla-more-columns.tsx
@@ -2,7 +2,6 @@ import classes from './finla-more-columns.module.css';
 import css from '@src/utils/css-utils.module.css';
 import { refTextContent } from '@src/utils/reactive-dom';
 import { fixed0 } from '@src/utils/format';
-import { applyCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 import { currentAssets } from '@src/core/balance/current-assets';
 
 function onTileReady(tile: PrunTile) {

--- a/src/features/basic/finla-more-columns.tsx
+++ b/src/features/basic/finla-more-columns.tsx
@@ -73,8 +73,7 @@ function hiddenIfZero(total: Ref<number | undefined>) {
 }
 
 function init() {
-  applyCssRule(`.${C.LiquidAssetsPanel.row} td:first-child`, classes.firstColumn);
-  applyCssRule(`.${C.LiquidAssetsPanel.row} td:not(:first-child)`, classes.otherColumns);
+  applyCssRule(`.${C.LiquidAssetsPanel.row}`, classes.row);
   tiles.observe('FINLA', onTileReady);
 }
 

--- a/src/features/basic/funny-rations.ts
+++ b/src/features/basic/funny-rations.ts
@@ -1,5 +1,4 @@
 import classes from './funny-rations.module.css';
-import { applyCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 import css from '@src/utils/css-utils.module.css';
 
 function applyFunny() {

--- a/src/features/basic/funny-rations.ts
+++ b/src/features/basic/funny-rations.ts
@@ -1,23 +1,23 @@
-import classes from './funny-rations.module.css';
+import $style from './funny-rations.module.css';
 import css from '@src/utils/css-utils.module.css';
 
 function applyFunny() {
   const today = new Date();
   if (today.getDate() === 1 && today.getMonth() === 3) {
-    document.body.classList.add(classes.funny);
+    document.body.classList.add($style.funny);
   } else {
-    document.body.classList.remove(classes.funny);
+    document.body.classList.remove($style.funny);
   }
 }
 
 function init() {
   setInterval(applyFunny, 60000);
 
-  applyCssRule(`.${classes.funny} .rp-ticker-RAT.${C.ColoredIcon.container}:before`, css.hidden);
-  applyCssRule(`.${classes.funny} .rp-ticker-RAT .${C.ColoredIcon.label}`, css.hidden);
+  applyCssRule(`.${$style.funny} .rp-ticker-RAT.${C.ColoredIcon.container}:before`, css.hidden);
+  applyCssRule(`.${$style.funny} .rp-ticker-RAT .${C.ColoredIcon.label}`, css.hidden);
   applyCssRule(
-    `.${classes.funny} .rp-ticker-RAT .${C.ColoredIcon.labelContainer}:after`,
-    classes.rat,
+    `.${$style.funny} .rp-ticker-RAT .${C.ColoredIcon.labelContainer}:after`,
+    $style.rat,
   );
 }
 

--- a/src/features/basic/hide-inactive-close-button.ts
+++ b/src/features/basic/hide-inactive-close-button.ts
@@ -1,4 +1,3 @@
-import { applyCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 import css from '@src/utils/css-utils.module.css';
 
 function init() {

--- a/src/features/basic/highlight-production-order-error.module.css
+++ b/src/features/basic/highlight-production-order-error.module.css
@@ -4,15 +4,15 @@
 
 .orderRow {
   position: relative;
-}
 
-.orderRowOverlay {
-  content: '';
-  background-color: rgba(217, 83, 79, 0.1);
-  position: absolute;
-  left: 0;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  pointer-events: none;
+  &:after {
+    content: '';
+    background-color: rgba(217, 83, 79, 0.1);
+    position: absolute;
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    pointer-events: none;
+  }
 }

--- a/src/features/basic/highlight-production-order-error.ts
+++ b/src/features/basic/highlight-production-order-error.ts
@@ -8,7 +8,6 @@ function init() {
     classes.inputMissingContainer,
   );
   applyScopedCssRule('PRODQ', `tr:has(.${C.OrderStatus.error})`, classes.orderRow);
-  applyScopedCssRule('PRODQ', `tr:has(.${C.OrderStatus.error}):after`, classes.orderRowOverlay);
   applyScopedCssRule(
     'PRODCO',
     `.${C.InputsOutputsView.input}:has(.${C.InputsOutputsView.amountMissing})`,

--- a/src/features/basic/highlight-production-order-error.ts
+++ b/src/features/basic/highlight-production-order-error.ts
@@ -1,16 +1,16 @@
-import classes from './highlight-production-order-error.module.css';
+import $style from './highlight-production-order-error.module.css';
 
 function init() {
   applyCssRule(
     'PROD',
     `.${C.OrderSlot.container}:has(.${C.OrderStatus.error})`,
-    classes.inputMissingContainer,
+    $style.inputMissingContainer,
   );
-  applyCssRule('PRODQ', `tr:has(.${C.OrderStatus.error})`, classes.orderRow);
+  applyCssRule('PRODQ', `tr:has(.${C.OrderStatus.error})`, $style.orderRow);
   applyCssRule(
     'PRODCO',
     `.${C.InputsOutputsView.input}:has(.${C.InputsOutputsView.amountMissing})`,
-    classes.inputMissingContainer,
+    $style.inputMissingContainer,
   );
 }
 

--- a/src/features/basic/highlight-production-order-error.ts
+++ b/src/features/basic/highlight-production-order-error.ts
@@ -1,14 +1,13 @@
-import { applyScopedCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 import classes from './highlight-production-order-error.module.css';
 
 function init() {
-  applyScopedCssRule(
+  applyCssRule(
     'PROD',
     `.${C.OrderSlot.container}:has(.${C.OrderStatus.error})`,
     classes.inputMissingContainer,
   );
-  applyScopedCssRule('PRODQ', `tr:has(.${C.OrderStatus.error})`, classes.orderRow);
-  applyScopedCssRule(
+  applyCssRule('PRODQ', `tr:has(.${C.OrderStatus.error})`, classes.orderRow);
+  applyCssRule(
     'PRODCO',
     `.${C.InputsOutputsView.input}:has(.${C.InputsOutputsView.amountMissing})`,
     classes.inputMissingContainer,

--- a/src/features/basic/input-math.ts
+++ b/src/features/basic/input-math.ts
@@ -3,7 +3,6 @@ import classes from './input-math.module.css';
 import { changeInputValue } from '@src/util';
 import Mexp from 'math-expression-evaluator';
 import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
-import { applyCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 
 const mexp = new Mexp();
 

--- a/src/features/basic/input-math.ts
+++ b/src/features/basic/input-math.ts
@@ -1,5 +1,5 @@
 import fa from '@src/utils/font-awesome.module.css';
-import classes from './input-math.module.css';
+import $style from './input-math.module.css';
 import { changeInputValue } from '@src/util';
 import Mexp from 'math-expression-evaluator';
 import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
@@ -65,13 +65,13 @@ function applyCssRules() {
   const inputSelector = `div:has(> input:is([inputmode='numeric'], [inputmode='decimal']):focus)`;
   // Remove hard-coded class when molp fixes class duplication
   const selector = `.FormComponent__input___f43wqaQ ${inputSelector}`;
-  applyCssRule(selector, classes.inputContainer);
+  applyCssRule(selector, $style.inputContainer);
   applyCssRule(`${selector}:before`, fa.solid);
-  applyCssRule(`${selector}:before`, classes.functionIcon);
+  applyCssRule(`${selector}:before`, $style.functionIcon);
   const selectorDynamic = `.${C.DynamicInput.dynamic} ${inputSelector}`;
-  applyCssRule(selectorDynamic, classes.inputContainer);
+  applyCssRule(selectorDynamic, $style.inputContainer);
   applyCssRule(`${selectorDynamic}:before`, fa.solid);
-  applyCssRule(`${selectorDynamic}:before`, classes.functionIconDynamic);
+  applyCssRule(`${selectorDynamic}:before`, $style.functionIconDynamic);
 }
 
 features.add(

--- a/src/features/basic/inv-compress-inventory-info.ts
+++ b/src/features/basic/inv-compress-inventory-info.ts
@@ -1,4 +1,4 @@
-import classes from './inv-compress-inventory-info.module.css';
+import $style from './inv-compress-inventory-info.module.css';
 
 async function onTileReady(tile: PrunTile) {
   subscribe($$(tile.anchor, C.StoreView.column), column => {
@@ -7,7 +7,7 @@ async function onTileReady(tile: PrunTile) {
       return;
     }
     const container = document.createElement('div');
-    container.classList.add(classes.capacityContainer);
+    container.classList.add($style.capacityContainer);
     container.appendChild(capacities[1]);
     container.appendChild(capacities[2]);
     capacities[0].after(container);
@@ -15,9 +15,9 @@ async function onTileReady(tile: PrunTile) {
 }
 
 function init() {
-  applyCssRule('INV', `.${C.StoreView.column}`, classes.storeViewColumn);
-  applyCssRule('INV', `.${C.StoreView.container}`, classes.storeViewContainer);
-  applyCssRule('INV', `.${C.InventorySortControls.controls}`, classes.sortControls);
+  applyCssRule('INV', `.${C.StoreView.column}`, $style.storeViewColumn);
+  applyCssRule('INV', `.${C.StoreView.container}`, $style.storeViewContainer);
+  applyCssRule('INV', `.${C.InventorySortControls.controls}`, $style.sortControls);
   tiles.observe('INV', onTileReady);
 }
 

--- a/src/features/basic/inv-compress-inventory-info.ts
+++ b/src/features/basic/inv-compress-inventory-info.ts
@@ -1,4 +1,3 @@
-import { applyScopedClassCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 import classes from './inv-compress-inventory-info.module.css';
 
 async function onTileReady(tile: PrunTile) {
@@ -16,9 +15,9 @@ async function onTileReady(tile: PrunTile) {
 }
 
 function init() {
-  applyScopedClassCssRule('INV', C.StoreView.column, classes.storeViewColumn);
-  applyScopedClassCssRule('INV', C.StoreView.container, classes.storeViewContainer);
-  applyScopedClassCssRule('INV', C.InventorySortControls.controls, classes.sortControls);
+  applyCssRule('INV', `.${C.StoreView.column}`, classes.storeViewColumn);
+  applyCssRule('INV', `.${C.StoreView.container}`, classes.storeViewContainer);
+  applyCssRule('INV', `.${C.InventorySortControls.controls}`, classes.sortControls);
   tiles.observe('INV', onTileReady);
 }
 

--- a/src/features/basic/inv-search.module.css
+++ b/src/features/basic/inv-search.module.css
@@ -1,12 +1,12 @@
 .inputText {
-  padding: 0px 5px;
+  padding: 0 5px;
   margin: 5px;
   background-color: #42361d;
-  border-width: 0px;
+  border-width: 0;
   border-bottom: 1px solid #8d6411;
   color: #cccccc;
-}
 
-.inputText:focus {
-  outline: none;
+  &:focus {
+    outline: none;
+  }
 }

--- a/src/features/basic/inv-search.tsx
+++ b/src/features/basic/inv-search.tsx
@@ -1,4 +1,4 @@
-import classes from './inv-search.module.css';
+import $style from './inv-search.module.css';
 import css from '@src/utils/css-utils.module.css';
 
 function onTileReady(tile: PrunTile) {
@@ -24,7 +24,7 @@ function onTileReady(tile: PrunTile) {
 
     createFragmentApp(() => (
       <div>
-        <input class={classes.inputText} placeholder="Enter location" onInput={onInput} />
+        <input class={$style.inputText} placeholder="Enter location" onInput={onInput} />
       </div>
     )).after(inventoryFilters);
   });

--- a/src/features/basic/item-icons.module.css
+++ b/src/features/basic/item-icons.module.css
@@ -1,29 +1,39 @@
 .container {
   container-type: size;
+
+  &:before {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0.25;
+    font-size: 2.2em;
+
+    @container (height < 24px) {
+      display: none;
+    }
+  }
 }
 
-.main {
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 0;
-  bottom: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  opacity: 0.25;
-  font-size: 2.2em;
-}
+.label {
+  &:before {
+    position: absolute;
+    left: 0;
+    right: 2px;
+    top: 2px;
+    bottom: 0;
+    display: flex;
+    justify-content: end;
+    line-height: 1;
+    opacity: 0.5;
+    text-shadow: none;
 
-.detail {
-  position: absolute;
-  left: 0;
-  right: 2px;
-  top: 2px;
-  bottom: 0;
-  display: flex;
-  justify-content: end;
-  line-height: 1;
-  opacity: 0.5;
-  text-shadow: none;
+    @container (height < 24px) {
+      display: none;
+    }
+  }
 }

--- a/src/features/basic/item-icons.ts
+++ b/src/features/basic/item-icons.ts
@@ -1,5 +1,5 @@
 import fa from '@src/utils/font-awesome.module.css';
-import classes from './item-icons.module.css';
+import $style from './item-icons.module.css';
 import { applyRawCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 import { objectKeys } from 'ts-extras';
 import { sanitizeCategoryName } from '@src/infrastructure/prun-ui/item-tracker';
@@ -8,9 +8,9 @@ function init() {
   const container = C.ColoredIcon.container;
   const label = C.ColoredIcon.label;
 
-  applyCssRule(`.${container}`, classes.container);
+  applyCssRule(`.${container}`, $style.container);
   applyCssRule(`.${container}:before`, fa.solid);
-  applyCssRule(`.${label}`, classes.label);
+  applyCssRule(`.${label}`, $style.label);
   applyCssRule(`.${label}:before`, fa.solid);
 
   for (const category of objectKeys(categories)) {

--- a/src/features/basic/item-icons.ts
+++ b/src/features/basic/item-icons.ts
@@ -1,6 +1,6 @@
 import fa from '@src/utils/font-awesome.module.css';
 import classes from './item-icons.module.css';
-import { applyCssRule, applyRawCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
+import { applyRawCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 import { objectKeys } from 'ts-extras';
 import { sanitizeCategoryName } from '@src/infrastructure/prun-ui/item-tracker';
 

--- a/src/features/basic/item-icons.ts
+++ b/src/features/basic/item-icons.ts
@@ -1,12 +1,6 @@
 import fa from '@src/utils/font-awesome.module.css';
-import css from '@src/utils/css-utils.module.css';
 import classes from './item-icons.module.css';
-import {
-  applyCssRule,
-  applyRawCssRule,
-  endCssAtScope,
-  startCssAtScope,
-} from '@src/infrastructure/prun-ui/refined-prun-css';
+import { applyCssRule, applyRawCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 import { objectKeys } from 'ts-extras';
 import { sanitizeCategoryName } from '@src/infrastructure/prun-ui/item-tracker';
 
@@ -16,14 +10,8 @@ function init() {
 
   applyCssRule(`.${container}`, classes.container);
   applyCssRule(`.${container}:before`, fa.solid);
-  applyCssRule(`.${container}:before`, classes.main);
+  applyCssRule(`.${label}`, classes.label);
   applyCssRule(`.${label}:before`, fa.solid);
-  applyCssRule(`.${label}:before`, classes.detail);
-
-  startCssAtScope('@container (height < 24px)');
-  applyCssRule(`.${container}:before`, css.hidden);
-  applyCssRule(`.${label}:before`, css.hidden);
-  endCssAtScope();
 
   for (const category of objectKeys(categories)) {
     applyIconRules(`.rp-category-${sanitizeCategoryName(category)}`, categories[category]);

--- a/src/features/basic/item-markers/IconMarker.vue
+++ b/src/features/basic/item-markers/IconMarker.vue
@@ -42,10 +42,10 @@ const boxStyle = computed(() => ({
   height: 100%;
   width: 100%;
   display: none;
-}
 
-.container:hover > .box {
-  display: block;
+  .container:hover > & {
+    display: block;
+  }
 }
 
 .icon {

--- a/src/features/basic/item-ticker-shadow.ts
+++ b/src/features/basic/item-ticker-shadow.ts
@@ -1,9 +1,8 @@
 import classes from './item-ticker-shadow.module.css';
-import { applyClassCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 
 function init() {
-  applyClassCssRule(C.ColoredIcon.label, classes.shadow);
-  applyClassCssRule(C.BuildingIcon.ticker, classes.shadow);
+  applyCssRule(`.${C.ColoredIcon.label}`, classes.shadow);
+  applyCssRule(`.${C.BuildingIcon.ticker}`, classes.shadow);
 }
 
 features.add(import.meta.url, init, 'Adds a shadow to item tickers.');

--- a/src/features/basic/item-ticker-shadow.ts
+++ b/src/features/basic/item-ticker-shadow.ts
@@ -1,8 +1,8 @@
-import classes from './item-ticker-shadow.module.css';
+import $style from './item-ticker-shadow.module.css';
 
 function init() {
-  applyCssRule(`.${C.ColoredIcon.label}`, classes.shadow);
-  applyCssRule(`.${C.BuildingIcon.ticker}`, classes.shadow);
+  applyCssRule(`.${C.ColoredIcon.label}`, $style.shadow);
+  applyCssRule(`.${C.BuildingIcon.ticker}`, $style.shadow);
 }
 
 features.add(import.meta.url, init, 'Adds a shadow to item tickers.');

--- a/src/features/basic/lm-highlight-own-ads.ts
+++ b/src/features/basic/lm-highlight-own-ads.ts
@@ -1,4 +1,4 @@
-import classes from './lm-highlight-own-ads.module.css';
+import $style from './lm-highlight-own-ads.module.css';
 import { companyStore } from '@src/infrastructure/prun-api/data/company';
 import { getPrunId } from '@src/infrastructure/prun-ui/attributes';
 import { localAdsStore } from '@src/infrastructure/prun-api/data/local-ads';
@@ -9,7 +9,7 @@ function onTileReady(tile: PrunTile) {
     const id = getPrunId(container);
     const ad = localAdsStore.getById(id);
     if (ad?.creator.id === companyStore.value?.id) {
-      item.classList.add(classes.ownAd);
+      item.classList.add($style.ownAd);
     }
   });
 }

--- a/src/features/basic/nots-notification-type-label.module.css
+++ b/src/features/basic/nots-notification-type-label.module.css
@@ -7,10 +7,10 @@
 .content {
   display: flex;
   flex-wrap: wrap;
-}
 
-.text {
-  flex: 1 1 200px;
+  > span:nth-child(2) {
+    flex: 1 1 200px;
+  }
 }
 
 .time {

--- a/src/features/basic/nots-notification-type-label.tsx
+++ b/src/features/basic/nots-notification-type-label.tsx
@@ -2,7 +2,6 @@ import classes from './nots-notification-type-label.module.css';
 import { getPrunId } from '@src/infrastructure/prun-ui/attributes';
 import { alertsStore } from '@src/infrastructure/prun-api/data/alerts';
 import { waitNotificationLoaded } from '@src/infrastructure/prun-ui/notifications';
-import { applyScopedCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 
 function onTileReady(tile: PrunTile) {
   subscribe($$(tile.anchor, C.AlertListItem.container), processNotification);
@@ -169,8 +168,8 @@ const labels: NotificationTypeLabel[] = [
 const labelMap = new Map(labels.flatMap(x => x.types.map(y => [y, x])));
 
 function init() {
-  applyScopedCssRule('NOTS', `.${C.AlertListItem.content}`, classes.content);
-  applyScopedCssRule('NOTS', `.${C.AlertListItem.time}`, classes.time);
+  applyCssRule('NOTS', `.${C.AlertListItem.content}`, classes.content);
+  applyCssRule('NOTS', `.${C.AlertListItem.time}`, classes.time);
 
   tiles.observe('NOTS', onTileReady);
 }

--- a/src/features/basic/nots-notification-type-label.tsx
+++ b/src/features/basic/nots-notification-type-label.tsx
@@ -171,7 +171,6 @@ const labelMap = new Map(labels.flatMap(x => x.types.map(y => [y, x])));
 function init() {
   applyScopedCssRule('NOTS', `.${C.AlertListItem.content}`, classes.content);
   applyScopedCssRule('NOTS', `.${C.AlertListItem.time}`, classes.time);
-  applyScopedCssRule('NOTS', `.${C.AlertListItem.content} > span:nth-child(2)`, classes.text);
 
   tiles.observe('NOTS', onTileReady);
 }

--- a/src/features/basic/nots-notification-type-label.tsx
+++ b/src/features/basic/nots-notification-type-label.tsx
@@ -1,4 +1,4 @@
-import classes from './nots-notification-type-label.module.css';
+import $style from './nots-notification-type-label.module.css';
 import { getPrunId } from '@src/infrastructure/prun-ui/attributes';
 import { alertsStore } from '@src/infrastructure/prun-api/data/alerts';
 import { waitNotificationLoaded } from '@src/infrastructure/prun-ui/notifications';
@@ -27,7 +27,7 @@ async function processNotification(container: HTMLElement) {
   }
 
   createFragmentApp(() => (
-    <div class={classes.label} style={{ color: label.color }}>
+    <div class={$style.label} style={{ color: label.color }}>
       {label.label}
     </div>
   )).before(textSpan);
@@ -168,8 +168,8 @@ const labels: NotificationTypeLabel[] = [
 const labelMap = new Map(labels.flatMap(x => x.types.map(y => [y, x])));
 
 function init() {
-  applyCssRule('NOTS', `.${C.AlertListItem.content}`, classes.content);
-  applyCssRule('NOTS', `.${C.AlertListItem.time}`, classes.time);
+  applyCssRule('NOTS', `.${C.AlertListItem.content}`, $style.content);
+  applyCssRule('NOTS', `.${C.AlertListItem.time}`, $style.time);
 
   tiles.observe('NOTS', onTileReady);
 }

--- a/src/features/basic/prodq-order-eta.module.css
+++ b/src/features/basic/prodq-order-eta.module.css
@@ -1,3 +1,5 @@
-.thCompletion {
-  width: min-content;
+.table {
+  thead tr th:nth-child(6) {
+    width: min-content;
+  }
 }

--- a/src/features/basic/prodq-order-eta.ts
+++ b/src/features/basic/prodq-order-eta.ts
@@ -42,11 +42,7 @@ function onOrderSlotReady(slot: HTMLElement, orderId: Ref<string | null>, siteId
 }
 
 function init() {
-  applyScopedCssRule(
-    'PRODQ',
-    `.${C.ProductionQueue.table} thead tr th:nth-child(6)`,
-    classes.thCompletion,
-  );
+  applyScopedCssRule('PRODQ', `.${C.ProductionQueue.table}`, classes.table);
   tiles.observe('PRODQ', onTileReady);
 }
 

--- a/src/features/basic/prodq-order-eta.ts
+++ b/src/features/basic/prodq-order-eta.ts
@@ -4,7 +4,6 @@ import { formatEta } from '@src/utils/format';
 import { timestampEachMinute } from '@src/utils/dayjs';
 import { createReactiveDiv } from '@src/utils/reactive-element';
 import { keepLast } from '@src/utils/keep-last';
-import { applyScopedCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 import classes from './prodq-order-eta.module.css';
 import { calcCompletionDate } from '@src/core/production-line';
 
@@ -42,7 +41,7 @@ function onOrderSlotReady(slot: HTMLElement, orderId: Ref<string | null>, siteId
 }
 
 function init() {
-  applyScopedCssRule('PRODQ', `.${C.ProductionQueue.table}`, classes.table);
+  applyCssRule('PRODQ', `.${C.ProductionQueue.table}`, classes.table);
   tiles.observe('PRODQ', onTileReady);
 }
 

--- a/src/features/basic/prodq-order-eta.ts
+++ b/src/features/basic/prodq-order-eta.ts
@@ -4,7 +4,7 @@ import { formatEta } from '@src/utils/format';
 import { timestampEachMinute } from '@src/utils/dayjs';
 import { createReactiveDiv } from '@src/utils/reactive-element';
 import { keepLast } from '@src/utils/keep-last';
-import classes from './prodq-order-eta.module.css';
+import $style from './prodq-order-eta.module.css';
 import { calcCompletionDate } from '@src/core/production-line';
 
 function onTileReady(tile: PrunTile) {
@@ -41,7 +41,7 @@ function onOrderSlotReady(slot: HTMLElement, orderId: Ref<string | null>, siteId
 }
 
 function init() {
-  applyCssRule('PRODQ', `.${C.ProductionQueue.table}`, classes.table);
+  applyCssRule('PRODQ', `.${C.ProductionQueue.table}`, $style.table);
   tiles.observe('PRODQ', onTileReady);
 }
 

--- a/src/features/basic/prun-bugs.module.css
+++ b/src/features/basic/prun-bugs.module.css
@@ -6,8 +6,10 @@
   z-index: 2;
 }
 
-.userInfo {
-  flex-shrink: 0;
+.head {
+  > div:nth-child(2) {
+    flex-shrink: 0;
+  }
 }
 
 .gridItem {

--- a/src/features/basic/prun-bugs.ts
+++ b/src/features/basic/prun-bugs.ts
@@ -1,9 +1,4 @@
 import { getPrunCssStylesheets } from '@src/infrastructure/prun-ui/prun-css';
-import {
-  applyClassCssRule,
-  applyCssRule,
-  applyScopedClassCssRule,
-} from '@src/infrastructure/prun-ui/refined-prun-css';
 import { changeInputValue } from '@src/util';
 import classes from './prun-bugs.module.css';
 
@@ -26,11 +21,15 @@ function removeMobileCssRules() {
 }
 
 function fixZOrder() {
-  applyClassCssRule(
-    [C.ComExOrdersPanel.filter, C.LocalMarket.filter, C.ContractsListTable.filter],
+  applyCssRule(
+    [
+      `.${C.ComExOrdersPanel.filter}`,
+      `.${C.LocalMarket.filter}`,
+      `.${C.ContractsListTable.filter}`,
+    ],
     classes.filter,
   );
-  applyClassCssRule(C.ScrollView.track, classes.scrollTrack);
+  applyCssRule(`.${C.ScrollView.track}`, classes.scrollTrack);
 }
 
 function fixContractConditionEditor() {
@@ -59,20 +58,16 @@ function init() {
   applyCssRule(`.${C.Head.container}`, classes.head);
 
   // Removes GridItemView background color.
-  applyClassCssRule(C.GridItemView.container, classes.gridItem);
+  applyCssRule(`.${C.GridItemView.container}`, classes.gridItem);
 
   // Adds text centering to GridItemView name.
-  applyClassCssRule(C.GridItemView.name, classes.gridItemName);
+  applyCssRule(`.${C.GridItemView.name}`, classes.gridItemName);
 
   // The overlay stops materials from being clickable
-  applyScopedClassCssRule(['PROD', 'PRODQ'], C.OrderTile.overlay, classes.disablePointerEvents);
+  applyCssRule(['PROD', 'PRODQ'], `.${C.OrderTile.overlay}`, classes.disablePointerEvents);
 
   // Prevent PROD buffer vertical scroll bar gutter from being always visible
-  applyScopedClassCssRule(
-    'PROD',
-    C.SiteProductionLines.container,
-    classes.containerScrollbarGutter,
-  );
+  applyCssRule('PROD', `.${C.SiteProductionLines.container}`, classes.containerScrollbarGutter);
 }
 
 features.add(import.meta.url, init, 'Fixes PrUn bugs.');

--- a/src/features/basic/prun-bugs.ts
+++ b/src/features/basic/prun-bugs.ts
@@ -56,7 +56,7 @@ function init() {
   fixContractConditionEditor();
 
   // Prevents top-right user info from shrinking.
-  applyCssRule(`.${C.Head.container} > div:nth-child(2)`, classes.userInfo);
+  applyCssRule(`.${C.Head.container}`, classes.head);
 
   // Removes GridItemView background color.
   applyClassCssRule(C.GridItemView.container, classes.gridItem);

--- a/src/features/basic/prun-bugs.ts
+++ b/src/features/basic/prun-bugs.ts
@@ -1,6 +1,6 @@
 import { getPrunCssStylesheets } from '@src/infrastructure/prun-ui/prun-css';
 import { changeInputValue } from '@src/util';
-import classes from './prun-bugs.module.css';
+import $style from './prun-bugs.module.css';
 
 function removeMobileCssRules() {
   const styles = getPrunCssStylesheets();
@@ -27,9 +27,9 @@ function fixZOrder() {
       `.${C.LocalMarket.filter}`,
       `.${C.ContractsListTable.filter}`,
     ],
-    classes.filter,
+    $style.filter,
   );
-  applyCssRule(`.${C.ScrollView.track}`, classes.scrollTrack);
+  applyCssRule(`.${C.ScrollView.track}`, $style.scrollTrack);
 }
 
 function fixContractConditionEditor() {
@@ -55,19 +55,19 @@ function init() {
   fixContractConditionEditor();
 
   // Prevents top-right user info from shrinking.
-  applyCssRule(`.${C.Head.container}`, classes.head);
+  applyCssRule(`.${C.Head.container}`, $style.head);
 
   // Removes GridItemView background color.
-  applyCssRule(`.${C.GridItemView.container}`, classes.gridItem);
+  applyCssRule(`.${C.GridItemView.container}`, $style.gridItem);
 
   // Adds text centering to GridItemView name.
-  applyCssRule(`.${C.GridItemView.name}`, classes.gridItemName);
+  applyCssRule(`.${C.GridItemView.name}`, $style.gridItemName);
 
   // The overlay stops materials from being clickable
-  applyCssRule(['PROD', 'PRODQ'], `.${C.OrderTile.overlay}`, classes.disablePointerEvents);
+  applyCssRule(['PROD', 'PRODQ'], `.${C.OrderTile.overlay}`, $style.disablePointerEvents);
 
   // Prevent PROD buffer vertical scroll bar gutter from being always visible
-  applyCssRule('PROD', `.${C.SiteProductionLines.container}`, classes.containerScrollbarGutter);
+  applyCssRule('PROD', `.${C.SiteProductionLines.container}`, $style.containerScrollbarGutter);
 }
 
 features.add(import.meta.url, init, 'Fixes PrUn bugs.');

--- a/src/features/basic/rprun-version-label.module.css
+++ b/src/features/basic/rprun-version-label.module.css
@@ -1,5 +1,7 @@
-.grow {
-  flex-grow: 1;
+.foot {
+  > span {
+    flex-grow: 1;
+  }
 }
 
 .container {

--- a/src/features/basic/rprun-version-label.tsx
+++ b/src/features/basic/rprun-version-label.tsx
@@ -1,4 +1,4 @@
-import classes from './rprun-version-label.module.css';
+import $style from './rprun-version-label.module.css';
 
 async function onFooterReady(footer: HTMLElement) {
   const userCount = await $(footer, C.UsersOnlineCount.container);
@@ -9,11 +9,11 @@ async function onFooterReady(footer: HTMLElement) {
 
   createFragmentApp(() => (
     <div
-      class={[classes.container, C.HeadItem.container, C.fonts.fontRegular, C.type.typeRegular]}
+      class={[$style.container, C.HeadItem.container, C.fonts.fontRegular, C.type.typeRegular]}
       onClick={onClick}>
       <div class={[C.HeadItem.indicator, C.HeadItem.indicatorSuccess]} />
       <div
-        class={[classes.label, C.HeadItem.label]}
+        class={[$style.label, C.HeadItem.label]}
         data-tooltip="Refined PrUn version."
         data-tooltip-position="top">
         v. {config.version}
@@ -23,7 +23,7 @@ async function onFooterReady(footer: HTMLElement) {
 }
 
 function init() {
-  applyCssRule(`.${C.Frame.foot}`, classes.foot);
+  applyCssRule(`.${C.Frame.foot}`, $style.foot);
   subscribe($$(document, C.Frame.foot), onFooterReady);
 }
 

--- a/src/features/basic/rprun-version-label.tsx
+++ b/src/features/basic/rprun-version-label.tsx
@@ -1,5 +1,4 @@
 import classes from './rprun-version-label.module.css';
-import { applyCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 
 async function onFooterReady(footer: HTMLElement) {
   const userCount = await $(footer, C.UsersOnlineCount.container);

--- a/src/features/basic/rprun-version-label.tsx
+++ b/src/features/basic/rprun-version-label.tsx
@@ -24,7 +24,7 @@ async function onFooterReady(footer: HTMLElement) {
 }
 
 function init() {
-  applyCssRule(`.${C.Frame.foot} > span`, classes.grow);
+  applyCssRule(`.${C.Frame.foot}`, classes.foot);
   subscribe($$(document, C.Frame.foot), onFooterReady);
 }
 

--- a/src/features/basic/screen-tab-bar/TabBar.vue
+++ b/src/features/basic/screen-tab-bar/TabBar.vue
@@ -35,9 +35,9 @@ function getScreen(id: string) {
   display: inline-flex;
   flex-wrap: wrap;
   overflow: hidden;
-}
 
-.container > * {
-  flex-shrink: 0;
+  > * {
+    flex-shrink: 0;
+  }
 }
 </style>

--- a/src/features/basic/screen-tab-bar/screen-tab-bar.module.css
+++ b/src/features/basic/screen-tab-bar/screen-tab-bar.module.css
@@ -1,9 +1,9 @@
 .screenControls {
   display: inline-flex;
-}
 
-.screenControlsItems {
-  flex-shrink: 0;
+  > :not(:last-child) {
+    flex-shrink: 0;
+  }
 }
 
 .hideButton {

--- a/src/features/basic/screen-tab-bar/screen-tab-bar.tsx
+++ b/src/features/basic/screen-tab-bar/screen-tab-bar.tsx
@@ -5,7 +5,7 @@ import removeArrayElement from '@src/utils/remove-array-element';
 import { isDefined } from 'ts-extras';
 import { watchEffectWhileNodeAlive } from '@src/utils/watch';
 import { syncState } from '@src/features/basic/screen-tab-bar/sync';
-import { applyClassCssRule, applyCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
+import { applyClassCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 
 function onListReady(list: HTMLElement) {
   subscribe($$(list, C.ScreenControls.screen), onScreenItemReady);
@@ -78,7 +78,6 @@ function init() {
   });
   subscribe($$(document, C.ScreenControls.screens), onListReady);
   applyClassCssRule(C.ScreenControls.container, classes.screenControls);
-  applyCssRule(`.${C.ScreenControls.container} > *:not(:last-child)`, classes.screenControlsItems);
 }
 
 features.add(import.meta.url, init, 'Adds a tab bar for user screens.');

--- a/src/features/basic/screen-tab-bar/screen-tab-bar.tsx
+++ b/src/features/basic/screen-tab-bar/screen-tab-bar.tsx
@@ -1,4 +1,4 @@
-import classes from './screen-tab-bar.module.css';
+import $style from './screen-tab-bar.module.css';
 import TabBar from './TabBar.vue';
 import { userData } from '@src/store/user-data';
 import removeArrayElement from '@src/utils/remove-array-element';
@@ -42,9 +42,9 @@ async function onScreenItemReady(item: HTMLElement) {
 
   watchEffectWhileNodeAlive(name, () => {
     if (hidden.value) {
-      name.classList.add(classes.hiddenName);
+      name.classList.add($style.hiddenName);
     } else {
-      name.classList.remove(classes.hiddenName);
+      name.classList.remove($style.hiddenName);
     }
   });
 
@@ -60,7 +60,7 @@ async function onScreenItemReady(item: HTMLElement) {
 
   createFragmentApp(() => (
     <div
-      class={[C.ScreenControls.delete, C.ScreenControls.copy, C.type.typeSmall, classes.hideButton]}
+      class={[C.ScreenControls.delete, C.ScreenControls.copy, C.type.typeSmall, $style.hideButton]}
       onClick={onClick}>
       {hidden.value ? 'shw' : 'hide'}
     </div>
@@ -76,7 +76,7 @@ function init() {
     createFragmentApp(TabBar).appendTo(container);
   });
   subscribe($$(document, C.ScreenControls.screens), onListReady);
-  applyCssRule(`.${C.ScreenControls.container}`, classes.screenControls);
+  applyCssRule(`.${C.ScreenControls.container}`, $style.screenControls);
 }
 
 features.add(import.meta.url, init, 'Adds a tab bar for user screens.');

--- a/src/features/basic/screen-tab-bar/screen-tab-bar.tsx
+++ b/src/features/basic/screen-tab-bar/screen-tab-bar.tsx
@@ -5,7 +5,6 @@ import removeArrayElement from '@src/utils/remove-array-element';
 import { isDefined } from 'ts-extras';
 import { watchEffectWhileNodeAlive } from '@src/utils/watch';
 import { syncState } from '@src/features/basic/screen-tab-bar/sync';
-import { applyClassCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 
 function onListReady(list: HTMLElement) {
   subscribe($$(list, C.ScreenControls.screen), onScreenItemReady);
@@ -77,7 +76,7 @@ function init() {
     createFragmentApp(TabBar).appendTo(container);
   });
   subscribe($$(document, C.ScreenControls.screens), onListReady);
-  applyClassCssRule(C.ScreenControls.container, classes.screenControls);
+  applyCssRule(`.${C.ScreenControls.container}`, classes.screenControls);
 }
 
 features.add(import.meta.url, init, 'Adds a tab bar for user screens.');

--- a/src/features/basic/sidebar-contracts-details/sidebar-contracts-details.module.css
+++ b/src/features/basic/sidebar-contracts-details/sidebar-contracts-details.module.css
@@ -3,8 +3,8 @@
   width: 65px;
   color: #3fa2de;
   cursor: pointer;
-}
 
-.contractId:hover {
-  color: #f7a600;
+  &:hover {
+    color: #f7a600;
+  }
 }

--- a/src/features/basic/sidebar-contracts-details/sidebar-contracts-details.ts
+++ b/src/features/basic/sidebar-contracts-details/sidebar-contracts-details.ts
@@ -2,7 +2,6 @@ import css from '@src/utils/css-utils.module.css';
 import classes from './sidebar-contracts-details.module.css';
 import ContractPartnerName from './ContractPartnerName.vue';
 import { refTextContent } from '@src/utils/reactive-dom';
-import { applyCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
 
 function onContractIdReady(id: HTMLElement) {

--- a/src/features/basic/sidebar-contracts-details/sidebar-contracts-details.ts
+++ b/src/features/basic/sidebar-contracts-details/sidebar-contracts-details.ts
@@ -18,7 +18,6 @@ function onContractIdReady(id: HTMLElement) {
 function init() {
   applyCssRule(`.${C.Sidebar.contract} .${C.Link.link}`, css.hidden);
   applyCssRule(`.${C.Sidebar.contractId}`, classes.contractId);
-  applyCssRule(`.${C.Sidebar.contractId}:hover`, `${classes.contractId}:hover`);
   subscribe($$(document, C.Sidebar.contractId), onContractIdReady);
 }
 

--- a/src/features/basic/sidebar-contracts-details/sidebar-contracts-details.ts
+++ b/src/features/basic/sidebar-contracts-details/sidebar-contracts-details.ts
@@ -1,5 +1,5 @@
 import css from '@src/utils/css-utils.module.css';
-import classes from './sidebar-contracts-details.module.css';
+import $style from './sidebar-contracts-details.module.css';
 import ContractPartnerName from './ContractPartnerName.vue';
 import { refTextContent } from '@src/utils/reactive-dom';
 import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
@@ -16,7 +16,7 @@ function onContractIdReady(id: HTMLElement) {
 
 function init() {
   applyCssRule(`.${C.Sidebar.contract} .${C.Link.link}`, css.hidden);
-  applyCssRule(`.${C.Sidebar.contractId}`, classes.contractId);
+  applyCssRule(`.${C.Sidebar.contractId}`, $style.contractId);
   subscribe($$(document, C.Sidebar.contractId), onContractIdReady);
 }
 

--- a/src/features/basic/table-rows-alternating-colors.module.css
+++ b/src/features/basic/table-rows-alternating-colors.module.css
@@ -1,23 +1,25 @@
-.evenRow {
-  position: relative;
-
-  &:after {
-    content: '';
-    background-color: rgba(255, 255, 255, 0.02);
-    position: absolute;
-    left: 0;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    pointer-events: none;
-  }
-
-  /*
-   This rule fixes a Firefox bug where vertical lines
-   would render thinner than expected (particularly visible in LEAD)
-  */
-
-  > * {
+.table {
+  tbody tr:nth-child(even) {
     position: relative;
+
+    &:after {
+      content: '';
+      background-color: rgba(255, 255, 255, 0.02);
+      position: absolute;
+      left: 0;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      pointer-events: none;
+    }
+
+    /*
+     This rule fixes a Firefox bug where vertical lines
+     would render thinner than expected (particularly visible in LEAD)
+    */
+
+    > * {
+      position: relative;
+    }
   }
 }

--- a/src/features/basic/table-rows-alternating-colors.ts
+++ b/src/features/basic/table-rows-alternating-colors.ts
@@ -1,7 +1,7 @@
-import classes from './table-rows-alternating-colors.module.css';
+import $style from './table-rows-alternating-colors.module.css';
 
 function init() {
-  applyCssRule('table', classes.table);
+  applyCssRule('table', $style.table);
 }
 
 features.add(import.meta.url, init, 'Colors even rows in lighter color in all tables.');

--- a/src/features/basic/table-rows-alternating-colors.ts
+++ b/src/features/basic/table-rows-alternating-colors.ts
@@ -2,7 +2,7 @@ import classes from './table-rows-alternating-colors.module.css';
 import { applyCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 
 function init() {
-  applyCssRule('table tbody tr:nth-child(even)', classes.evenRow);
+  applyCssRule('table', classes.table);
 }
 
 features.add(import.meta.url, init, 'Colors even rows in lighter color in all tables.');

--- a/src/features/basic/table-rows-alternating-colors.ts
+++ b/src/features/basic/table-rows-alternating-colors.ts
@@ -1,5 +1,4 @@
 import classes from './table-rows-alternating-colors.module.css';
-import { applyCssRule } from '@src/infrastructure/prun-ui/refined-prun-css';
 
 function init() {
   applyCssRule('table', classes.table);

--- a/src/infrastructure/prun-ui/refined-prun-css.ts
+++ b/src/infrastructure/prun-ui/refined-prun-css.ts
@@ -8,51 +8,49 @@ export function loadRefinedPrunCss() {
   css.textContent = null;
 }
 
-export function applyClassCssRule(classNames: Arrayable<string>, sourceClass: string) {
-  for (const className of castArray(classNames)) {
-    applyCssRule(`.${className}`, sourceClass);
-  }
-}
-
-export function applyScopedClassCssRule(
-  commands: Arrayable<string>,
-  classNames: Arrayable<string>,
-  sourceClass: string,
-) {
-  classNames = castArray(classNames);
-  for (const command of castArray(commands)) {
-    for (const className of classNames) {
-      applyCssRule(`${selectCommand(command)} .${className}`, sourceClass);
-    }
-  }
-}
-
-export function applyScopedCssRule(
+export function applyCssRule(selectors: Arrayable<string>, sourceClass: string): void;
+export function applyCssRule(
   commands: Arrayable<string>,
   selectors: Arrayable<string>,
   sourceClass: string,
-) {
-  selectors = castArray(selectors);
-  for (const command of castArray(commands)) {
-    for (const selector of selectors) {
-      applyCssRule(`${selectCommand(command)} ${selector}`, sourceClass);
-    }
-  }
-}
+): void;
 
-export function applyCssRule(selector: string, sourceClass: string) {
-  if (!sourceClass) {
-    throw new Error('Source class is undefined');
-  }
+export function applyCssRule(arg1: Arrayable<string>, arg2: Arrayable<string>, arg3?: string) {
   if (!features.current) {
     throw new Error('Cannot apply css rules outside of feature init');
+  }
+  let commands: string[];
+  let selectors: string[];
+  let sourceClass: string;
+  if (arguments.length === 2) {
+    commands = [];
+    selectors = castArray(arg1);
+    sourceClass = arg2 as string;
+  } else {
+    commands = castArray(arg1);
+    selectors = castArray(arg2);
+    sourceClass = arg3 as string;
+  }
+
+  if (!sourceClass) {
+    throw new Error('Source class is undefined');
   }
   const sourceSelector = '.' + sourceClass;
   const match = rules[sourceSelector];
   if (!match) {
     throw new Error(`Failed to find css selector ${sourceSelector}`);
   }
-  applyRawCssRule(match.replace(sourceSelector, selector));
+  if (commands.length > 0) {
+    for (const selector of selectors) {
+      for (const command of commands) {
+        applyRawCssRule(match.replace(sourceSelector, `${selectCommand(command)} ${selector}`));
+      }
+    }
+  } else {
+    for (const selector of selectors) {
+      applyRawCssRule(match.replace(sourceSelector, selector));
+    }
+  }
 }
 
 let currentSheet = {

--- a/src/infrastructure/prun-ui/refined-prun-css.ts
+++ b/src/infrastructure/prun-ui/refined-prun-css.ts
@@ -55,16 +55,6 @@ export function applyCssRule(selector: string, sourceClass: string) {
   applyRawCssRule(match.replace(sourceSelector, selector));
 }
 
-let at: string | undefined = undefined;
-
-export function startCssAtScope(scope: string) {
-  at = scope;
-}
-
-export function endCssAtScope() {
-  at = undefined;
-}
-
 let currentSheet = {
   id: '',
   textContent: '',
@@ -82,7 +72,7 @@ export function applyRawCssRule(rule: string) {
   } else {
     currentSheet.textContent += '\n\n';
   }
-  currentSheet.textContent += at ? `${at} ${wrapInBrackets(rule)}` : rule;
+  currentSheet.textContent += rule;
 }
 
 function queueSheetAppend() {

--- a/src/types/unimport.d.ts
+++ b/src/types/unimport.d.ts
@@ -6,6 +6,7 @@ declare global {
   const EffectScope: typeof import('vue')['EffectScope'];
   const _$$: typeof import('@src/utils/select-dom')['_$$'];
   const _$: typeof import('@src/utils/select-dom')['_$'];
+  const applyCssRule: typeof import('@src/infrastructure/prun-ui/refined-prun-css')['applyCssRule'];
   const computed: typeof import('vue')['computed'];
   const config: typeof import('@src/infrastructure/shell/config')['default'];
   const createApp: typeof import('vue')['createApp'];
@@ -100,6 +101,7 @@ declare module 'vue' {
     readonly EffectScope: UnwrapRef<typeof import('vue')['EffectScope']>;
     readonly _$$: UnwrapRef<typeof import('@src/utils/select-dom')['_$$']>;
     readonly _$: UnwrapRef<typeof import('@src/utils/select-dom')['_$']>;
+    readonly applyCssRule: UnwrapRef<typeof import('@src/infrastructure/prun-ui/refined-prun-css')['applyCssRule']>;
     readonly computed: UnwrapRef<typeof import('vue')['computed']>;
     readonly config: UnwrapRef<typeof import('@src/infrastructure/shell/config')['default']>;
     readonly createApp: UnwrapRef<typeof import('vue')['createApp']>;

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -53,6 +53,7 @@ export default defineConfig({
         { name: 'default', as: 'xit', from: '@src/features/XIT/xit-registry' },
         { name: 'default', as: 'config', from: '@src/infrastructure/shell/config' },
         { name: 'createFragmentApp', from: '@src/utils/vue-fragment-app' },
+        { name: 'applyCssRule', from: '@src/infrastructure/prun-ui/refined-prun-css' },
       ],
       //dts: 'src/types/unimport.d.ts',
       addons: {


### PR DESCRIPTION
This PR aims to simplify and standardize CSS-touching code. In short:

- Use CSS nesting where appropriate
- Make `applyCssRule` globally available via unimport
- Remove all versions of the `applyCssRule` function (scoped/class) and have just one function to rule them all
- When importing classes from CSS modules into feature files, do it with a `$style` object name for consistency with Vue `$style` object
- Add documentation covering basics of working with CSS in this project

@CoroNaut, please give your feedback regarding these changes and review the documentation for clarity:
https://github.com/refined-prun/refined-prun/blob/working-with-css/docs/contributing/working-with-css.md