### PR TITLE
Backend planets type

### DIFF
--- a/src/infrastructure/prun-api/data/planets.ts
+++ b/src/infrastructure/prun-api/data/planets.ts
@@ -2,6 +2,7 @@ import { createEntityStore } from '@src/infrastructure/prun-api/data/create-enti
 import { onApiMessage } from '@src/infrastructure/prun-api/data/api-messages';
 import { createMapGetter } from '@src/infrastructure/prun-api/data/create-map-getter';
 import { isEmpty } from 'ts-extras';
+import { request } from './request-hooks';
 
 const store = createEntityStore<PrunApi.Planet>(x => x.naturalId.toLowerCase(), {
   preserveOnOpen: true,
@@ -18,7 +19,6 @@ onApiMessage({
     if (isEmpty(data.path) || data.path[0] !== 'planets' || data.path[2]) {
       return;
     }
-    console.log(data.body);
     store.setOne(data.body);
     store.setFetched();
   },
@@ -31,9 +31,19 @@ const getByName = createMapGetter(state.all, x => x.name);
 const find = (naturalIdOrName?: string | null) =>
   getByNaturalId(naturalIdOrName) ?? getByName(naturalIdOrName);
 
+const getPlanetInfo = (naturalId?: string | null) => {
+  const planet = getByNaturalId(naturalId);
+  if (!planet?.id && planet?.naturalId) {
+    request.planet(planet?.naturalId);
+    return undefined;
+  }
+  return planet;
+};
+
 export const planetsStore = {
   ...state,
   getByNaturalId,
   getByName,
   find,
+  getPlanetInfo,
 };

--- a/src/infrastructure/prun-api/data/planets.ts
+++ b/src/infrastructure/prun-api/data/planets.ts
@@ -3,26 +3,22 @@ import { onApiMessage } from '@src/infrastructure/prun-api/data/api-messages';
 import { createMapGetter } from '@src/infrastructure/prun-api/data/create-map-getter';
 import { isEmpty } from 'ts-extras';
 
-interface ShortPlanet {
-  naturalId: string;
-  name: string;
-}
-
-const store = createEntityStore<ShortPlanet>(x => x.naturalId.toLowerCase(), {
+const store = createEntityStore<PrunApi.Planet>(x => x.naturalId.toLowerCase(), {
   preserveOnOpen: true,
 });
 const state = store.state;
 
 onApiMessage({
-  FIO_PLANET_DATA(data: { planets: ShortPlanet[] }) {
+  FIO_PLANET_DATA(data: { planets: PrunApi.Planet[] }) {
     store.setAll(data.planets);
     store.setFetched();
   },
 
-  DATA_DATA(data: { body: Arrayable<PrunApi.Planet>; path: string[] }) {
-    if (isEmpty(data.path) || data.path[0] !== 'planets') {
+  DATA_DATA(data: { body: PrunApi.Planet; path: string[] }) {
+    if (isEmpty(data.path) || data.path[0] !== 'planets' || data.path[2]) {
       return;
     }
+    console.log(data.body);
     store.setOne(data.body);
     store.setFetched();
   },

--- a/src/infrastructure/prun-api/data/planets.ts
+++ b/src/infrastructure/prun-api/data/planets.ts
@@ -1,20 +1,29 @@
 import { createEntityStore } from '@src/infrastructure/prun-api/data/create-entity-store';
 import { onApiMessage } from '@src/infrastructure/prun-api/data/api-messages';
 import { createMapGetter } from '@src/infrastructure/prun-api/data/create-map-getter';
+import { isEmpty } from 'ts-extras';
 
-interface Planet {
+interface ShortPlanet {
   naturalId: string;
   name: string;
 }
 
-const store = createEntityStore<Planet>(x => x.naturalId.toLowerCase(), {
+const store = createEntityStore<ShortPlanet>(x => x.naturalId.toLowerCase(), {
   preserveOnOpen: true,
 });
 const state = store.state;
 
 onApiMessage({
-  FIO_PLANET_DATA(data: { planets: Planet[] }) {
+  FIO_PLANET_DATA(data: { planets: ShortPlanet[] }) {
     store.setAll(data.planets);
+    store.setFetched();
+  },
+
+  DATA_DATA(data: { body: Arrayable<PrunApi.Planet>; path: string[] }) {
+    if (isEmpty(data.path) || data.path[0] !== 'planets') {
+      return;
+    }
+    store.setOne(data.body);
     store.setFetched();
   },
 });

--- a/src/infrastructure/prun-api/data/planets.types.d.ts
+++ b/src/infrastructure/prun-api/data/planets.types.d.ts
@@ -47,22 +47,10 @@ declare namespace PrunApi {
   }
 
   interface PlanetProductionFee {
-    category: PlanetWorkforceCategory;
+    category: ExpertiseCategory;
     fee: Cost;
-    workforceLevel: PlanetWorkforceLevel;
+    workforceLevel: WorkforceLevel;
   }
-
-  type PlanetWorkforceCategory =
-    | 'AGRICULTURE'
-    | 'CHEMISTRY'
-    | 'CONSTRUCTION'
-    | 'ELECTRONICS'
-    | 'FOOD_INDUSTRIES'
-    | 'FUEL_REFINING'
-    | 'MANUFACTURING'
-    | 'METALLURGY'
-    | 'RESOURCE_EXTRACTION';
-  type PlanetWorkforceLevel = 'PIONEER' | 'SETTLER' | 'TECHNICIAN' | 'ENGINEER' | 'SCIENTIST';
 
   interface PlanetMarketFee {
     base: number;

--- a/src/infrastructure/prun-api/data/planets.types.d.ts
+++ b/src/infrastructure/prun-api/data/planets.types.d.ts
@@ -1,0 +1,139 @@
+declare namespace PrunApi {
+  interface Planet {
+    address: Address;
+    adminCenterId: string;
+    buildOptions: BuildOptions[];
+    celestialBodies: unknown[];
+    cogcId: string;
+    country: Country;
+    currency: Currency;
+    data: PlanetData;
+    governanceType: string;
+    governingEntity: string;
+    id: string;
+    localRules: PlanetLocalRules;
+    name: string;
+    nameable: boolean;
+    namer: string | null;
+    namingData: DateTime | null;
+    naturalId: string;
+    planetId: string;
+    populationId: string;
+    projects: PlanetProject[];
+    supportsGhostSites: boolean;
+  }
+
+  interface PlanetProject {
+    entityId: string;
+    type: string;
+  }
+
+  interface PlanetLocalRules {
+    collector: PlanetCollector;
+    currency: Currency;
+    localMarketFee: PlanetMarketFee;
+    productionFeeLimitFactors: number[];
+    productionFees: PlanetProductionFees;
+    siteEstablishmentFee: PlanetFee;
+    warehouseFee: PlanetFee;
+  }
+
+  interface PlanetFee {
+    fee: number;
+  }
+
+  interface PlanetProductionFees {
+    fees: PlanetProductionFee[];
+  }
+
+  interface PlanetProductionFee {
+    category: PlanetWorkforceCategory;
+    fee: Cost;
+    workforceLevel: PlanetWorkforceLevel;
+  }
+
+  type PlanetWorkforceCategory =
+    | 'AGRICULTURE'
+    | 'CHEMISTRY'
+    | 'CONSTRUCTION'
+    | 'ELECTRONICS'
+    | 'FOOD_INDUSTRIES'
+    | 'FUEL_REFINING'
+    | 'MANUFACTURING'
+    | 'METALLURGY'
+    | 'RESOURCE_EXTRACTION';
+  type PlanetWorkforceLevel = 'PIONEER' | 'SETTLER' | 'TECHNICIAN' | 'ENGINEER' | 'SCIENTIST';
+
+  interface PlanetMarketFee {
+    base: number;
+    timeFactor: number;
+  }
+
+  interface PlanetCollector {
+    currency: Currency;
+  }
+
+  interface PlanetData {
+    fertility: number;
+    gravity: number;
+    magneticField: number;
+    mass: number;
+    massEarth: AddressOrbit;
+    orbitIndex: number;
+    plots: number;
+    pressure: number;
+    radiation: number;
+    radius: number;
+    resources: PlanetResource[];
+    sunlight: number;
+    surface: boolean;
+    temperature: number;
+  }
+
+  interface PlanetResource {
+    factor: number;
+    materialId: string;
+    type: ResourceType;
+  }
+
+  type ResourceType = 'GASEOUS' | 'LIQUID' | 'MINERAL';
+
+  interface Country {
+    code: CountryCode;
+    id: string;
+    name: CountryName;
+  }
+
+  type CountryCode = 'CI' | 'NC' | 'IC' | 'AI';
+  type CountryName =
+    | 'Castillo-Ito Mercantile'
+    | 'NEO Charter Exploration'
+    | 'Insitor Cooperative'
+    | 'Antares Initiative';
+
+  interface Currency {
+    code: CurrencyCode;
+    decimals: number;
+    name: CurrencyName;
+    numericCode: number;
+  }
+
+  type CurrencyCode = 'CIS' | 'NCC' | 'ICA' | 'AIC';
+  type CurrencyName = 'Sol' | 'NCE Coupons' | 'Austral' | 'Martian Coin';
+
+  interface BuildOptions {
+    options: BuildOption[];
+  }
+
+  interface BuildOption {
+    billOfMaterial: MaterialQuantities;
+    costs: Cost;
+    feeReceiver: string;
+    siteType: string;
+  }
+
+  interface Cost {
+    amount: number;
+    currency: string;
+  }
+}

--- a/src/infrastructure/prun-api/data/request-hooks.ts
+++ b/src/infrastructure/prun-api/data/request-hooks.ts
@@ -6,6 +6,7 @@ interface RequestHooks {
   blueprints(): void;
   shipyards(): void;
   shipyardProjects(): void;
+  planet(naturalId?: string | null): void;
 }
 
 let hooks: RequestHooks | undefined = undefined;
@@ -35,6 +36,9 @@ export const request = {
   },
   shipyardProjects(): void {
     getHooks().shipyardProjects();
+  },
+  planet(naturalId?: string | null): void {
+    getHooks().planet(naturalId);
   },
 };
 

--- a/src/infrastructure/shell/request-hooks.ts
+++ b/src/infrastructure/shell/request-hooks.ts
@@ -8,6 +8,7 @@ import { fxosStore } from '@src/infrastructure/prun-api/data/fxos';
 import { blueprintsStore } from '@src/infrastructure/prun-api/data/blueprints';
 import { shipyardsStore } from '@src/infrastructure/prun-api/data/shipyards';
 import { shipyardProjectsStore } from '@src/infrastructure/prun-api/data/shipyard-projects';
+import { planetsStore } from '../prun-api/data/planets';
 
 const bs: Set<string> = new Set();
 
@@ -56,4 +57,9 @@ implementRequestHooks({
   blueprints: singleBufferRequest('BLU', () => blueprintsStore.fetched.value),
   shipyards: singleBufferRequest('SHY', () => shipyardsStore.fetched.value),
   shipyardProjects: singleBufferRequest('SHYP', () => shipyardProjectsStore.fetched.value),
+  planet: naturalId =>
+    singleBufferRequest(
+      `BSC ${naturalId}`,
+      () => planetsStore.getByNaturalId(naturalId)?.id !== undefined,
+    )(),
 });


### PR DESCRIPTION
I extended the `PrunApi.Planet` type to include all relevant information from the api object. This is purely a backend change. I can use `getPlanetInfo` to get planet specific building materials for a building TODO task #44. This can also help gather information for a `XIT GOV` buffer like in #62. Just this data alone can be used for local rules and basic planet projects info.

I was also looking at getting populations data as well. This would enable more features for a `XIT GOV`. The populationId in a planet could connect to a populationsStore. populationsStore would deal in lots of planet government data like COGC, POPI, contributions, upkeeps, workforce data, etc.

Similarly, I was also thinking of a `buildingStore` store that would get request building data like workforce, type, building materials, recipes, etc. 

I'm unsure if you just want the stores in `prun-api/data` to be for more commonly used data or if its fine to make stores for more niche information. I don't have any plans to request any more information than necessary for any specific task. Alternatively, I could make FIO requests for all these information types, planets, buildings, populations, etc.

I tested the `getPlanetInfo` function and it works similarly to other `request` functions.