### PR TITLE
Feature `exp-expert-eta`

### DIFF
--- a/src/features/advanced/exp-expert-eta.ts
+++ b/src/features/advanced/exp-expert-eta.ts
@@ -25,6 +25,9 @@ function onTileReady(tile: PrunTile) {
   let index = 0;
   subscribe($$(tile.anchor, 'tr'), tr => {
     if (_$(tr, 'th')) {
+      const header = document.createElement('th');
+      header.textContent = 'Expert ETA';
+      tr.append(header);
       return;
     }
     onExpertRowReady(tr, index++, site.siteId);
@@ -92,14 +95,15 @@ function onExpertRowReady(row: HTMLTableRowElement, index: number, siteId: strin
     } else if (completion.value[0] === -1) {
       return 'Experts Maxed.';
     } else if (completion.value[0] === -2) {
-      return `${formatEta(timestampEachMinute.value, completion.value[1])}`;
+      return `(${formatEta(timestampEachMinute.value, completion.value[1])})`;
     } else if (completion.value[0] === -3) {
-      return `(${formatEta(timestampEachMinute.value, completion.value[1])}) + (${formatDuration(completion.value[2])}) more of orders`;
+      return `(${formatEta(timestampEachMinute.value, completion.value[1])}) +\n(${formatDuration(completion.value[2])}) needed`;
     }
     return `Error`;
   });
 
   const div = createReactiveDiv(row, text);
+  div.style.whiteSpace = 'pre-wrap';
   const td = document.createElement('td');
   td.append(div);
   row.append(td);

--- a/src/features/advanced/exp-expert-eta.tsx
+++ b/src/features/advanced/exp-expert-eta.tsx
@@ -1,0 +1,150 @@
+import Tooltip from '@src/components/Tooltip.vue';
+import { expertsStore } from '@src/infrastructure/prun-api/data/experts';
+import { productionStore } from '@src/infrastructure/prun-api/data/production';
+import { request } from '@src/infrastructure/prun-api/data/request-hooks';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { timestampEachMinute } from '@src/utils/dayjs';
+import { formatEta } from '@src/utils/format';
+import { createReactiveDiv } from '@src/utils/reactive-element';
+
+const expertise = [
+  'AGRICULTURE',
+  'CHEMISTRY',
+  'CONSTRUCTION',
+  'ELECTRONICS',
+  'FOOD_INDUSTRIES',
+  'FUEL_REFINING',
+  'MANUFACTURING',
+  'METALLURGY',
+  'RESOURCE_EXTRACTION',
+];
+
+const expertDays = [10.0, 12.5, 57.57, 276.5, 915.1];
+
+function onTileReady(tile: PrunTile) {
+  const site = sitesStore.getById(tile.parameter)!;
+
+  let index = 0;
+  subscribe($$(tile.anchor, 'tr'), tr => {
+    if (_$(tr, 'th')) {
+      createFragmentApp(() => (
+        <th>
+          Expert Eta
+          <Tooltip
+            style="float: revert; padding-top: 0;"
+            position="left"
+            tooltip="ETA will be exact if you will get a new expert with your current orders, and approximate if your current orders are not enough."
+          />
+        </th>
+      )).appendTo(tr);
+      return;
+    }
+    onExpertRowReady(tr, index++, site.siteId);
+  });
+}
+
+function onExpertRowReady(row: HTMLTableRowElement, index: number, siteId: string) {
+  const expertField = computed(() => {
+    const experts = expertsStore.getBySiteId(siteId);
+    return experts?.experts.find(field => field.category === expertise[index]);
+  });
+
+  request.production(siteId);
+  const expertOrders = computed(() => {
+    const production = productionStore.getBySiteId(siteId);
+    // Combine all production orders from all lines that contribute to this expert field.
+    const expertFieldLines = production?.filter(line =>
+      line.efficiencyFactors.some(
+        factor => factor.type === 'EXPERTS' && factor.expertiseCategory === expertise[index],
+      ),
+    );
+    // Sort them by ascending completion time if ongoing, and by ascending creation time if queued.
+    return expertFieldLines
+      ?.flatMap(line => line.orders)
+      .sort((a, b) => {
+        if (!a.completion && !b.completion) {
+          return a.created.timestamp - b.created.timestamp;
+        }
+        if (!a.completion) {
+          return 1;
+        }
+        if (!b.completion) {
+          return -1;
+        }
+        return a.completion!.timestamp - b.completion!.timestamp;
+      });
+  });
+
+  const completion = computed(() => {
+    if (!expertField.value) {
+      return undefined;
+    }
+    if (expertField.value.entry.current === 5) {
+      return [-1];
+    }
+    const orders = expertOrders.value;
+    if (orders && orders.length > 0) {
+      const entry = expertField.value.entry;
+      const msToGo = (1 - entry.progress) * expertDays[entry.current] * 86400000;
+
+      // Get completion time and duration for all orders, including queued ones.
+      const completions: number[] = [];
+      let contributingOrdersTime = 0;
+      for (const order of orders) {
+        const duration = order.completion
+          ? order.completion!.timestamp - Date.now()
+          : order.duration!.millis;
+        contributingOrdersTime += duration;
+        if (order.completion) {
+          completions.push(order.completion.timestamp);
+        } else {
+          completions.push(completions.shift()! + duration);
+          completions.sort();
+        }
+        if (contributingOrdersTime > msToGo) {
+          return [-2, completions[completions.length - 1]];
+        }
+      }
+
+      // All ongoing and queued orders completed, but we still need more for a new expert.
+      return [-3, completions[completions.length - 1], msToGo - contributingOrdersTime];
+    }
+    return undefined;
+  });
+
+  const text = computed(() => {
+    if (!completion.value) {
+      return 'No production.';
+    } else if (completion.value[0] === -1) {
+      return 'Experts Maxed.';
+    } else if (completion.value[0] === -2) {
+      return `${formatEta(timestampEachMinute.value, completion.value[1])}`;
+    } else if (completion.value[0] === -3) {
+      return `After (${formatEta(timestampEachMinute.value, completion.value[1])}) and (${formatDuration(completion.value[2])}) more of orders`;
+    }
+    return `DON'T LOOK! I'M A BUG!`;
+  });
+
+  const div = createReactiveDiv(row, text);
+  const td = document.createElement('td');
+  td.append(div);
+  row.append(td);
+}
+
+function formatDuration(millis: number) {
+  const seconds = Math.floor(millis / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  const remainingHours = hours % 24;
+  const remainingMinutes = minutes % 60;
+
+  return `${days}d, ${remainingHours}h, ${remainingMinutes}m`;
+}
+
+function init() {
+  tiles.observe('EXP', onTileReady);
+}
+
+features.add(import.meta.url, init, 'EXP: Display ETA for next expert to appear.');

--- a/src/features/advanced/index.ts
+++ b/src/features/advanced/index.ts
@@ -7,6 +7,7 @@ import './cogcpex-clean-labels';
 import './context-controls-no-hover';
 import './cxos-hide-exchange';
 import './cxpo-shorten-fields';
+import './exp-expert-eta';
 import './finla-hide-ecd';
 import './flt-flight-status-icons';
 import './flt-hide-transponder';

--- a/src/infrastructure/prun-api/data/experts.ts
+++ b/src/infrastructure/prun-api/data/experts.ts
@@ -1,0 +1,20 @@
+import { createEntityStore } from '@src/infrastructure/prun-api/data/create-entity-store';
+import { onApiMessage } from '@src/infrastructure/prun-api/data/api-messages';
+import { createMapGetter } from '@src/infrastructure/prun-api/data/create-map-getter';
+
+const store = createEntityStore<PrunApi.Experts>(x => x.siteId);
+const state = store.state;
+
+onApiMessage({
+  EXPERTS_EXPERTS(data: PrunApi.Experts) {
+    store.setOne(data);
+    store.setFetched();
+  },
+});
+
+const getBySiteId = createMapGetter(state.all, x => x.siteId);
+
+export const expertsStore = {
+  ...state,
+  getBySiteId,
+};

--- a/src/infrastructure/prun-api/data/experts.types.d.ts
+++ b/src/infrastructure/prun-api/data/experts.types.d.ts
@@ -1,0 +1,38 @@
+declare namespace PrunApi {
+  export interface Experts {
+    active: ExpertsTotalAllowed;
+    address: Address;
+    experts: ExpertField[];
+    siteId: string;
+    total: ExpertsTotalAllowed;
+    totalActiveCap: 6;
+  }
+
+  export interface ExpertField {
+    category: ExpertCategory;
+    entry: ExpertFieldEntry;
+  }
+
+  export interface ExpertFieldEntry {
+    available: ExpertsFieldAllowed;
+    category: ExpertCategory;
+    current: ExpertsFieldAllowed;
+    efficiencyGain: number;
+    limit: 5;
+    progress: number;
+  }
+
+  export type ExpertsFieldAllowed = 0 | 1 | 2 | 3 | 4 | 5;
+  export type ExpertsTotalAllowed = ExpertsFieldAllowed | 6;
+
+  export type ExpertCategory =
+    | 'AGRICULTURE'
+    | 'CHEMISTRY'
+    | 'CONSTRUCTION'
+    | 'ELECTRONICS'
+    | 'FOOD_INDUSTRIES'
+    | 'FUEL_REFINING'
+    | 'MANUFACTURING'
+    | 'METALLURGY'
+    | 'RESOURCE_EXTRACTION';
+}


### PR DESCRIPTION
Similar to knowing when your orders are going to complete, or ship is going to arrive, experts also have an ETA. This PR adds another column to the experts window that calculates when another expert will show up. If you have orders in your production line that are enough to get a new expert, the time shows exactly when you get that new expert. If you are working on the 5th expert in a field, it may be 50days away, so it will calculate up to your last production line order, and then display how many more orders you need.

First picture shows all ETAs and the RIG doesn't have enough orders to make a new expert.
Second picture shows RIG with additional orders, and now has an exact ETA.
<details>

![Capture](https://github.com/user-attachments/assets/71dd49bc-7c4e-4f5a-ae48-a32af6db5200)
![Capture2](https://github.com/user-attachments/assets/bdc4b10f-e3a9-481f-9d6d-d3510467b60e)

</details>