### PR TITLE
XIT Burn - Option to show actual consumption when input shortage stops a production line

### DIFF
--- a/src/features/XIT/BURN/tile-state.ts
+++ b/src/features/XIT/BURN/tile-state.ts
@@ -5,5 +5,6 @@ export const useTileState = createTileStateHook({
   yellow: true,
   green: true,
   inf: true,
+  out: true,
   expand: [] as string[],
 });


### PR DESCRIPTION
As someone trying to balance my RAT production across many different recipes to keep costs down, I occasionally run out of an input or two. I would like to know what my _actual_ consumption looks like, in case I don't get a resupply of that particular crop.

I have implemented this to look like this:
<img width="485" height="359" alt="image" src="https://github.com/user-attachments/assets/cd522559-ad98-42ed-b4b7-8955ed6e2d1d" />

<img width="473" height="359" alt="image" src="https://github.com/user-attachments/assets/696e787c-efc9-4787-8e2e-89dd3dad4664" />

I hope this will make a valuable inclusion in the extension and I would be glad to work with you to improve the implementation.
Particularly, I would like to find a way to avoid including notStoppedBurn in the PlanetBurn interface but this seems like the least disruptive method from what I could glean of the structure of the extension.
