### PR TITLE
Custom upkeeps

### DIFF
--- a/src/features/XIT/ACT/material-groups/resupply/Edit.vue
+++ b/src/features/XIT/ACT/material-groups/resupply/Edit.vue
@@ -33,6 +33,8 @@ const exclusions = ref(group.exclusions?.join(', ') ?? '');
 
 const useBaseInventory = ref(group.useBaseInv ?? true);
 
+const useCustomUpkeeps = ref(group.useCustomUpkeeps ?? false);
+
 const workforceOnly = ref(group.consumablesOnly ?? false);
 
 function validate() {
@@ -52,6 +54,7 @@ function save() {
     .map(x => materialsStore.getByTicker(x.trim())?.ticker)
     .filter(x => x !== undefined);
   group.useBaseInv = useBaseInventory.value;
+  group.useCustomUpkeeps = useCustomUpkeeps.value;
   group.consumablesOnly = workforceOnly.value;
 }
 
@@ -77,6 +80,11 @@ defineExpose({ validate, save });
     label="Use Base Inv"
     tooltip="Whether to count the materials currently in the base towards the totals.">
     <RadioItem v-model="useBaseInventory">use base inv</RadioItem>
+  </Active>
+  <Active
+    label="Use Custom Upkeep"
+    tooltip="Whether to consider custom upkeeps as defined in XIT UPKEEP.">
+    <RadioItem v-model="useCustomUpkeeps">use custom upkeep</RadioItem>
   </Active>
   <Active
     label="Workforce Only"

--- a/src/features/XIT/ACT/material-groups/resupply/resupply.ts
+++ b/src/features/XIT/ACT/material-groups/resupply/resupply.ts
@@ -13,6 +13,7 @@ import {
   getEntityNameFromAddress,
   getEntityNaturalIdFromAddress,
 } from '@src/infrastructure/prun-api/data/addresses';
+import { userData } from '@src/store/user-data.ts';
 
 act.addMaterialGroup<Config>({
   type: 'Resupply',
@@ -57,11 +58,13 @@ act.addMaterialGroup<Config>({
       );
     }
     const stores = storagesStore.getByAddressableId(site.siteId);
+    const upkeeps = userData.upkeeps[site.siteId];
 
     const planetBurn = calculatePlanetBurn(
       data.consumablesOnly ? undefined : production.value,
       workforce.value,
       (data.useBaseInv ?? true) ? stores : undefined,
+      upkeeps, // ADD AN OPTION TO IGNORE THIS
     );
 
     const parsedGroup = {};

--- a/src/features/XIT/ACT/material-groups/resupply/resupply.ts
+++ b/src/features/XIT/ACT/material-groups/resupply/resupply.ts
@@ -64,7 +64,7 @@ act.addMaterialGroup<Config>({
       data.consumablesOnly ? undefined : production.value,
       workforce.value,
       (data.useBaseInv ?? true) ? stores : undefined,
-      upkeeps, // ADD AN OPTION TO IGNORE THIS
+      data.useCustomUpkeeps ? upkeeps : undefined,
     );
 
     const parsedGroup = {};

--- a/src/features/XIT/BURN/PlanetHeader.vue
+++ b/src/features/XIT/BURN/PlanetHeader.vue
@@ -30,6 +30,9 @@ const days = computed(() => countDays(burn.burn));
         <PrunButton dark inline @click="showBuffer(`INV ${burn.storeId.substring(0, 8)}`)">
           INV
         </PrunButton>
+        <PrunButton dark inline @click="showBuffer(`XIT UPKEEP ${burn.naturalId}`)"
+          >UPKEEP</PrunButton
+        >
       </div>
     </td>
   </tr>

--- a/src/features/XIT/UPKEEP/MaterialRow.vue
+++ b/src/features/XIT/UPKEEP/MaterialRow.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+import { materialsStore } from '@src/infrastructure/prun-api/data/materials.ts';
+import NumericInput from '@src/components/forms/NumericInput.vue';
+import PrunButton from '@src/components/PrunButton.vue';
+import MaterialIcon from '@src/components/MaterialIcon.vue';
+import TextInput from '@src/components/forms/TextInput.vue';
+import { deleteUpkeep } from '@src/store/upkeeps.ts';
+
+const { upkeep } = defineProps<{
+  upkeep: UserData.Upkeep;
+}>();
+
+if (upkeep.matAmounts.length < 1) {
+  upkeep.matAmounts.push({ material: materialsStore.getByTicker('RAT')!, amount: 10 });
+}
+
+const data = ref({
+  ticker: upkeep.matAmounts[0].material.ticker,
+  amount: upkeep.matAmounts[0].amount,
+  days: upkeep.duration.millis / 1000 / 60 / 60 / 24,
+});
+
+watch(
+  data,
+  value => {
+    upkeep.matAmounts[0].amount = value.amount;
+    upkeep.matAmounts[0].material =
+      materialsStore.getByTicker(value.ticker) ?? materialsStore.getByTicker('RAT')!;
+    upkeep.duration.millis = value.days * 24 * 60 * 60 * 1000;
+  },
+  { deep: true },
+);
+
+const onDeleteClick = () => {
+  deleteUpkeep(upkeep);
+};
+</script>
+
+<template>
+  <tr>
+    <td :class="$style.materialContainer">
+      <MaterialIcon size="inline-table" :ticker="data.ticker" />
+    </td>
+    <td :class="$style.tickerCell">
+      <div :class="[C.forms.input, $style.inline]">
+        <TextInput v-model="data.ticker" />
+      </div>
+    </td>
+    <td :class="$style.amountCell">
+      <div :class="[C.forms.input, $style.inline]">
+        <NumericInput v-model="data.amount" />
+      </div>
+    </td>
+    <td :class="$style.daysCell">
+      <div :class="[C.forms.input, $style.inline]">
+        <NumericInput v-model="data.days" />
+      </div>
+    </td>
+    <td :class="$style.rateCell">
+      {{ data.amount >= 0 ? '+' : '' }}{{ Math.round((data.amount / data.days) * 100) / 100 }}
+    </td>
+    <td>
+      <PrunButton danger @click="onDeleteClick">DEL</PrunButton>
+    </td>
+  </tr>
+</template>
+
+<style module>
+.inline {
+  display: inline-block;
+}
+
+.materialContainer {
+  width: 32px;
+  padding: 0;
+}
+
+.tickerCell * {
+  width: 40px;
+}
+
+.amountCell * {
+  width: 60px;
+}
+
+.daysCell * {
+  width: 40px;
+}
+
+.rateCell * {
+  width: 80px;
+}
+</style>

--- a/src/features/XIT/UPKEEP/PlanetHeader.vue
+++ b/src/features/XIT/UPKEEP/PlanetHeader.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import PrunButton from '@src/components/PrunButton.vue';
+import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses.ts';
+import { createUpkeep } from '@src/store/upkeeps.ts';
+
+const { site, onClick, minimized } = defineProps<{
+  site: PrunApi.Site;
+  hasMinimize?: boolean;
+  minimized?: boolean;
+  onClick: () => void;
+}>();
+
+const onAddClick = () => {
+  createUpkeep('', site.siteId);
+  if (minimized) {
+    onClick();
+  }
+};
+</script>
+
+<template>
+  <tr :class="$style.row">
+    <td colspan="5" :class="$style.cell" @click="onClick">
+      <span v-if="hasMinimize" :class="$style.minimize">
+        {{ minimized ? '+' : '-' }}
+      </span>
+      <span>{{ getEntityNameFromAddress(site.address) }}</span>
+    </td>
+    <td>
+      <div :class="$style.buttons">
+        <PrunButton primary inline @click="onAddClick">ADD</PrunButton>
+      </div>
+    </td>
+  </tr>
+</template>
+
+<style module>
+.row {
+  border-bottom: 1px solid #2b485a;
+}
+
+.cell {
+  font-weight: bold;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.minimize {
+  display: inline-block;
+  width: 26px;
+  text-align: center;
+}
+
+.buttons {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  column-gap: 0.25rem;
+}
+</style>

--- a/src/features/XIT/UPKEEP/UPKEEP.ts
+++ b/src/features/XIT/UPKEEP/UPKEEP.ts
@@ -1,0 +1,21 @@
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites.ts';
+import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses.ts';
+import UPKEEP from '@src/features/XIT/UPKEEP/UPKEEP.vue';
+
+xit.add({
+  command: ['UPKEEP', 'UPKEEPS'],
+  name: parameters => {
+    if (parameters[0] && !parameters[1]) {
+      const site = sitesStore.getByPlanetNaturalIdOrName(parameters[0]);
+      if (site) {
+        const name = getEntityNameFromAddress(site.address);
+        return `UPKEEP - ${name}`;
+      }
+    }
+
+    return 'UPKEEP';
+  },
+  description: 'Configure custom upkeep costs.',
+  optionalParameters: 'Planet Identifier(s), OVERALL',
+  component: () => UPKEEP,
+});

--- a/src/features/XIT/UPKEEP/UPKEEP.vue
+++ b/src/features/XIT/UPKEEP/UPKEEP.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+import { useXitParameters } from '@src/hooks/use-xit-parameters';
+import { userData } from '@src/store/user-data';
+import { isEmpty } from 'ts-extras';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites.ts';
+import { useTileState } from '@src/features/XIT/UPKEEP/tile-state.ts';
+import UpkeepSection from '@src/features/XIT/UPKEEP/UpkeepSection.vue';
+import { createId } from '@src/store/create-id.ts';
+import { materialsStore } from '@src/infrastructure/prun-api/data/materials.ts';
+import MaterialRow from '@src/features/XIT/UPKEEP/MaterialRow.vue';
+
+const parameters = useXitParameters();
+
+const isUpkeepAll = isEmpty(parameters) || parameters[0].toLowerCase() == 'all';
+
+const sites = computed(() => {
+  if (isUpkeepAll) {
+    return sitesStore.all.value;
+  }
+
+  return parameters.map(x => sitesStore.getByPlanetNaturalIdOrName(x)).filter(x => x !== undefined);
+});
+
+const upkeeps = computed(
+  () =>
+    Object.fromEntries(
+      (sites.value ?? []).map(site => {
+        return [site.siteId, userData.upkeeps[site.siteId]];
+      }),
+    ) as Record<string, UserData.Upkeep[]>,
+);
+
+const expand = useTileState('expand');
+
+const anyExpanded = computed(() => expand.value.length > 0);
+
+function onExpandAllClick() {
+  if (expand.value.length > 0) {
+    expand.value = [];
+  } else {
+    expand.value = Object.keys(upkeeps.value);
+  }
+}
+
+const fakeUpkeep: UserData.Upkeep = {
+  id: createId(),
+  siteId: sites.value![0].siteId,
+  name: '',
+  duration: {
+    millis: 1000,
+  },
+  matAmounts: [
+    {
+      material: materialsStore.getByTicker('RAT')!,
+      amount: 1,
+    },
+  ],
+};
+</script>
+
+<template>
+  <table>
+    <thead>
+      <tr>
+        <th v-if="sites && sites.length > 0" :class="$style.expand" @click="onExpandAllClick">
+          {{ anyExpanded ? '-' : '+' }}
+        </th>
+        <th v-else />
+        <th>Ticker</th>
+        <th>Amount</th>
+        <th>Days</th>
+        <th>Daily</th>
+        <th>CMD</th>
+      </tr>
+    </thead>
+    <tbody :class="$style.fakeRow">
+      <MaterialRow :upkeep="fakeUpkeep" />
+    </tbody>
+    <UpkeepSection
+      v-for="site in sites"
+      :key="site.siteId"
+      :site="site"
+      :can-minimize="sites && sites.length > 1"
+      :upkeeps="upkeeps[site.siteId]" />
+  </table>
+</template>
+
+<style module>
+.expand {
+  text-align: center;
+  cursor: pointer;
+  user-select: none;
+  font-size: 12px;
+  padding-left: 18px;
+  font-weight: bold;
+}
+
+.fakeRow {
+  visibility: collapse;
+}
+</style>

--- a/src/features/XIT/UPKEEP/UpkeepSection.vue
+++ b/src/features/XIT/UPKEEP/UpkeepSection.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { useTileState } from '@src/features/XIT/BURN/tile-state.ts';
+import PlanetHeader from '@src/features/XIT/UPKEEP/PlanetHeader.vue';
+import MaterialRow from '@src/features/XIT/UPKEEP/MaterialRow.vue';
+
+const { site, upkeeps, canMinimize } = defineProps<{
+  site: PrunApi.Site;
+  upkeeps: UserData.Upkeep[];
+  canMinimize?: boolean;
+}>();
+
+const expand = useTileState('expand');
+
+const isMinimized = computed(() => canMinimize && !expand.value.includes(site.siteId));
+
+const onHeaderClick = () => {
+  if (!canMinimize) {
+    return;
+  }
+  if (isMinimized.value) {
+    expand.value = [...expand.value, site.siteId];
+  } else {
+    expand.value = expand.value.filter(x => x !== site.siteId);
+  }
+};
+</script>
+
+<template>
+  <tbody>
+    <PlanetHeader
+      :site="site"
+      :on-click="onHeaderClick"
+      :has-minimize="canMinimize"
+      :minimized="isMinimized" />
+  </tbody>
+  <tbody v-if="!isMinimized && upkeeps && upkeeps.length > 0">
+    <MaterialRow v-for="upkeep in upkeeps" :key="upkeep.id" :upkeep="upkeep" />
+  </tbody>
+</template>
+
+<style module></style>

--- a/src/features/XIT/UPKEEP/tile-state.ts
+++ b/src/features/XIT/UPKEEP/tile-state.ts
@@ -1,0 +1,5 @@
+import { createTileStateHook } from '@src/store/user-data-tiles';
+
+export const useTileState = createTileStateHook({
+  expand: [] as string[],
+});

--- a/src/features/XIT/index.ts
+++ b/src/features/XIT/index.ts
@@ -22,5 +22,6 @@ import './REP/REP';
 import './SET/SET';
 import './START';
 import './TODO/TODO';
+import './UPKEEP/UPKEEP';
 import './WEB/WEB';
 import './xit-commands';

--- a/src/store/upkeeps.ts
+++ b/src/store/upkeeps.ts
@@ -1,0 +1,29 @@
+import { userData } from '@src/store/user-data';
+import { createId } from '@src/store/create-id';
+import { materialsStore } from '@src/infrastructure/prun-api/data/materials.ts';
+
+export function createUpkeep(name: string, siteId: string) {
+  if (userData.upkeeps[siteId] == undefined) {
+    userData.upkeeps[siteId] = [];
+  }
+  const id = createId();
+  userData.upkeeps[siteId].push({
+    id,
+    siteId,
+    name,
+    duration: {
+      millis: 1000 * 60 * 60 * 24,
+    },
+    matAmounts: [
+      {
+        material: materialsStore.getByTicker('RAT')!,
+        amount: 10,
+      },
+    ],
+  });
+  return id;
+}
+
+export function deleteUpkeep(upkeep: UserData.Upkeep) {
+  userData.upkeeps[upkeep.siteId] = userData.upkeeps[upkeep.siteId].filter(x => x.id != upkeep.id);
+}

--- a/src/store/user-data.ts
+++ b/src/store/user-data.ts
@@ -58,6 +58,7 @@ export const initialUserData = deepFreeze({
     v1: [],
     v2: [],
   } as UserData.BalanceHistory,
+  upkeeps: {} as Record<string, UserData.Upkeep[]>,
   notes: [] as UserData.Note[],
   actionPackages: [] as UserData.ActionPackageData[],
   systemMessages: [] as UserData.SystemMessages[],

--- a/src/store/user-data.types.d.ts
+++ b/src/store/user-data.types.d.ts
@@ -65,6 +65,7 @@ declare namespace UserData {
     advanceDays?: number | string;
     planet?: string;
     useBaseInv?: boolean;
+    useCustomUpkeeps?: boolean;
     materials?: Record<string, number>;
     exclusions?: string[];
     consumablesOnly?: boolean;

--- a/src/store/user-data.types.d.ts
+++ b/src/store/user-data.types.d.ts
@@ -28,6 +28,14 @@ declare namespace UserData {
 
   type TileState = Record<string, unknown>;
 
+  interface Upkeep {
+    id: string;
+    siteId: string;
+    name: string;
+    duration: PrunApi.TimeSpan;
+    matAmounts: PrunApi.MaterialAmount[];
+  }
+
   interface Note {
     id: string;
     name: string;


### PR DESCRIPTION
Managing CoGC upkeeps can be a pain as there's nowhere to see a base's full logistical flow. So, I created XIT UPKEEP. This allows one to set custom production offsets for any base to account for any sort of niche scenario in a streamlined manner. Also integrated into XIT ACT resupply.

This probably needs a fair bit more testing for edge cases and what have you, but I wanted the code to be visible for review. I hope this, too, fits the scope of the extension and would be a desired addition.

<img width="1180" height="1001" alt="image" src="https://github.com/user-attachments/assets/9511ccce-f23d-4e1c-9fbe-a934d0b0f37b" />
<img width="1257" height="628" alt="image" src="https://github.com/user-attachments/assets/d07908ed-c52a-419e-92a3-800e5bf763af" />
