### PR TITLE
Calculate balance statement section totals even if some entries are undefined

### DIFF
--- a/src/core/balance/balance-sheet-summary.ts
+++ b/src/core/balance/balance-sheet-summary.ts
@@ -21,7 +21,12 @@ function calcSectionTotal<T extends BalanceSheetSection>(
     return section.total;
   }
 
-  return section.total ?? mapSum(...args.map(x => x(section)));
+  const calculated = args.map(x => x(section))
+  if (calculated.every(x => x === undefined)) {
+    return undefined;
+  }
+
+  return section.total ?? mapSum(...calculated.map(x => x ?? 0));
 }
 
 function less(value: number | undefined) {


### PR DESCRIPTION
Only returns undefined as balance statement section total, if all entries in the section are undefined.
Otherwise undefined entries are coerced to zero.

If a player has no cx storages or no "other items" in their inventory, the current balance will be calculated as undefined, which is displayed in the graphs as zero.
The player can however possess currency, which should be displayed in the balance statements total.

Hence only sections that are entirely undefined or zero should be interpreted as zero.