### PR TITLE
Fix off by one in burn and just fix the calculation rounding

### DIFF
--- a/src/features/XIT/ACT/material-groups/resupply/resupply.ts
+++ b/src/features/XIT/ACT/material-groups/resupply/resupply.ts
@@ -74,7 +74,11 @@ act.addMaterialGroup<Config>({
         continue;
       }
       const days = typeof data.days === 'number' ? data.days : parseFloat(data.days);
-      const need = Math.ceil((matBurn.daysLeft - days) * matBurn.dailyAmount);
+      let need = Math.ceil(-days * matBurn.dailyAmount - matBurn.inventory);
+      // If the daily need is less than 1, send an extra to avoid burn ticking over early
+      if (matBurn.dailyAmount < 1) {
+        need += 1;
+      }
       if (need > 0) {
         parsedGroup[ticker] = need;
       }


### PR DESCRIPTION

I noticed my resupplies were a little buggy sometimes and I was very annoyed when some low usage consumable would tick down and my BURN would say 0 days left suddenly when I actually had like a week. So now just throw an extra mat into the resupply to avoid BURN suddenly dropping. I've been using this for months and all my complaints about resupply is gone.


Little proof I scribbled to show it was the same calculation but avoided some rounding error:

Starting formula: `Math.ceil((matBurn.daysLeft - days) * matBurn.dailyAmount)`
Expand matBurn.daysLeft: `Math.ceil((Math.floor(-materialBurn.inventory / materialBurn.dailyAmount) - days) * matBurn.dailyAmount)`
Remove the inner floor (this is the rounding error): `Math.ceil(((-materialBurn.inventory / materialBurn.dailyAmount) - days) * matBurn.dailyAmount)`
Distribute: `Math.ceil(-materialBurn.inventory  - days * matBurn.dailyAmount)`