### PR TITLE
Add Stock Feature

### DIFF
--- a/src/features/XIT/ACT/material-groups/stock/Configure.vue
+++ b/src/features/XIT/ACT/material-groups/stock/Configure.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import SelectInput from '@src/components/forms/SelectInput.vue';
+import Active from '@src/components/forms/Active.vue';
+import { Config } from '@src/features/XIT/ACT/material-groups/stock/config';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses';
+import { comparePlanets } from '@src/util';
+
+const { config } = defineProps<{ data: UserData.MaterialGroupData; config: Config }>();
+
+const planets = computed(() =>
+  (sitesStore.all.value ?? [])
+    .map(x => getEntityNameFromAddress(x.address))
+    .filter(x => x !== undefined)
+    .sort(comparePlanets),
+);
+
+if (!config.planet) {
+  config.planet = planets.value[0];
+}
+</script>
+
+<template>
+  <form>
+    <Active label="Planet">
+      <SelectInput v-model="config.planet" :options="planets" />
+    </Active>
+  </form>
+</template>

--- a/src/features/XIT/ACT/material-groups/stock/Edit.vue
+++ b/src/features/XIT/ACT/material-groups/stock/Edit.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import Active from '@src/components/forms/Active.vue';
+import TextInput from '@src/components/forms/TextInput.vue';
+import NumberInput from '@src/components/forms/NumberInput.vue';
+import SelectInput from '@src/components/forms/SelectInput.vue';
+import Commands from '@src/components/forms/Commands.vue';
+import PrunButton from '@src/components/PrunButton.vue';
+import { objectId } from '@src/utils/object-id';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses';
+import { comparePlanets } from '@src/util';
+import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
+import { configurableValue } from '@src/features/XIT/ACT/shared-types';
+
+const { group } = defineProps<{ group: UserData.MaterialGroupData }>();
+
+// Planet selection logic (same as Resupply)
+const planets = computed(() => {
+  const planets = (sitesStore.all.value ?? [])
+    .map(x => getEntityNameFromAddress(x.address))
+    .filter(x => x !== undefined)
+    .sort(comparePlanets);
+  planets.unshift(configurableValue);
+  return planets;
+});
+
+const planet = ref(group.planet ?? planets.value[0]);
+const planetError = ref(false);
+
+// Material list logic (same as Manual)
+const materials = ref(getMaterials());
+const materialErrors = ref<boolean[]>([]);
+
+function getMaterials() {
+  const materials = group.materials ?? {};
+  return Object.keys(materials).map(x => [x, materials[x]]) as [string, number][];
+}
+
+function onAddClick() {
+  materials.value.push(['', 0]);
+}
+
+function validate() {
+  let isValid = true;
+  planetError.value = !planet.value;
+  isValid &&= !planetError.value;
+
+  const errors = materials.value.map(([ticker, amount]) => {
+    const material = materialsStore.getByTicker(ticker);
+    return !(material && amount > 0);
+  });
+  materialErrors.value = errors;
+
+  const hasValidMaterial = errors.some(error => !error);
+  if (!hasValidMaterial) {
+    isValid = false;
+  }
+  return isValid;
+}
+
+function save() {
+  group.planet = planet.value;
+  // Save material list
+  group.materials = {};
+  for (let [ticker, amount] of materials.value) {
+    const material = materialsStore.getByTicker(ticker);
+    if (!material || amount <= 0 || !isFinite(amount)) {
+      continue;
+    }
+    group.materials[material.ticker] = amount;
+  }
+}
+
+defineExpose({ validate, save });
+</script>
+
+<template>
+  <Active label="Planet" :error="planetError">
+    <SelectInput v-model="planet" :options="planets" />
+  </Active>
+  <template v-for="(pair, i) in materials" :key="objectId(pair)">
+    <Active :label="`Material Ticker #${i + 1}`" :error="materialErrors[i]">
+      <TextInput v-model="pair[0]" />
+    </Active>
+    <Active :label="`Material Amount #${i + 1}`">
+      <NumberInput v-model="pair[1]" />
+    </Active>
+  </template>
+  <Commands>
+    <PrunButton primary @click="onAddClick">ADD MATERIAL</PrunButton>
+  </Commands>
+</template>

--- a/src/features/XIT/ACT/material-groups/stock/config.ts
+++ b/src/features/XIT/ACT/material-groups/stock/config.ts
@@ -1,0 +1,3 @@
+export interface Config {
+  planet: string;
+}

--- a/src/features/XIT/ACT/material-groups/stock/stock.ts
+++ b/src/features/XIT/ACT/material-groups/stock/stock.ts
@@ -68,9 +68,9 @@ act.addMaterialGroup<Config>({
         continue;
       }
       const currentAmount = inventory.get(ticker) ?? 0;
-      const needed = targetAmount - currentAmount;
-      if (needed > 0) {
-        parsedGroup[ticker] = needed;
+      const need = targetAmount - currentAmount;
+      if (need > 0) {
+        parsedGroup[ticker] = need;
       }
     }
 

--- a/src/features/XIT/ACT/material-groups/stock/stock.ts
+++ b/src/features/XIT/ACT/material-groups/stock/stock.ts
@@ -1,0 +1,79 @@
+import { act } from '@src/features/XIT/ACT/act-registry';
+import Edit from '@src/features/XIT/ACT/material-groups/stock/Edit.vue';
+import Configure from '@src/features/XIT/ACT/material-groups/stock/Configure.vue';
+import { Config } from '@src/features/XIT/ACT/material-groups/stock/config';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
+import { configurableValue } from '@src/features/XIT/ACT/shared-types';
+import { fixed0 } from '@src/utils/format';
+
+act.addMaterialGroup<Config>({
+  type: 'Stock',
+  description: data => {
+    const materials = data.materials;
+    if (!materials || Object.keys(materials).length === 0) {
+      if (!data.planet) {
+        return '--';
+      }
+      return 'Stock on ' + data.planet;
+    }
+    const items = Object.keys(materials)
+      .map(ticker => `${fixed0(materials[ticker])} ${ticker}`)
+      .join(', ');
+    if (data.planet) {
+      return `Stock ${items} on ${data.planet}`;
+    }
+    return `Stock ${items}`;
+  },
+  editComponent: Edit,
+  configureComponent: Configure,
+  needsConfigure: data => data.planet === configurableValue,
+  isValidConfig: (data, config) => data.planet !== configurableValue || config.planet !== undefined,
+  generateMaterialBill: async ({ data, config, log }) => {
+    if (!data.planet) {
+      log.error('Missing stock planet');
+      return undefined;
+    }
+    const materials = data.materials;
+    if (!materials || Object.keys(materials).length === 0) {
+      log.error('Missing materials.');
+      return undefined;
+    }
+
+    const planet = data.planet === configurableValue ? config.planet : data.planet;
+    const site = sitesStore.getByPlanetNaturalIdOrName(planet);
+    if (!site) {
+      log.error(`Base is not present on ${planet}`);
+      return undefined;
+    }
+
+    const stores = storagesStore.getByAddressableId(site.siteId);
+    const inventory = new Map<string, number>();
+    if (stores) {
+      for (const store of stores) {
+        for (const item of store.items) {
+          if (!item.quantity) {
+            continue;
+          }
+          const ticker = item.quantity.material.ticker;
+          const existing = inventory.get(ticker) ?? 0;
+          inventory.set(ticker, existing + item.quantity.amount);
+        }
+      }
+    }
+
+    const parsedGroup: Record<string, number> = {};
+    for (const [ticker, targetAmount] of Object.entries(materials)) {
+      if (targetAmount <= 0) {
+        continue;
+      }
+      const currentAmount = inventory.get(ticker) ?? 0;
+      const needed = targetAmount - currentAmount;
+      if (needed > 0) {
+        parsedGroup[ticker] = needed;
+      }
+    }
+
+    return parsedGroup;
+  },
+});

--- a/src/store/user-data.types.d.ts
+++ b/src/store/user-data.types.d.ts
@@ -48,7 +48,7 @@ declare namespace UserData {
     };
   }
 
-  type MaterialGroupType = 'Manual' | 'Resupply' | 'Repair';
+  type MaterialGroupType = 'Manual' | 'Resupply' | 'Repair' | 'Stock';
 
   interface MaterialGroupData {
     type: MaterialGroupType;


### PR DESCRIPTION
### **Feature Overview**
Added a new XIT ACT material group type `Stock`, allowing users to manually define inventory target on their desire. The system calculates the difference between the target quantity and the existing stock.

### **Changes**
* **New Files:**
    * `src/features/XIT/ACT/material-groups/stock/Configure.vue` – Configuration component
    * `src/features/XIT/ACT/material-groups/stock/Edit.vue` – Editing component
    * `src/features/XIT/ACT/material-groups/stock/config.ts` – Configuration type definitions
    * `src/features/XIT/ACT/material-groups/stock/stock.ts` – Material group registration and generation logic
* **Type Updates:**
    * `src/store/user-data.types.d.ts` – Added `'Stock'` value to the `MaterialGroupType` enum.

### **Technical Implementation**
* Reused the `act.addMaterialGroup` registration mechanism, following the same pattern as `Manual`, `Resupply`, and `Repair`.
* Utilized `sitesStore` and `storagesStore` to fetch current inventory data.
* Supported the configuration parameter `configurableValue`, allowing users to select a target planet.
* Used `fixed0` for number formatting, complying with project formatting standards.

### **Testing Instructions**
1.  Create a new `Stock` material group in XIT ACT.
2.  Select a target planet and set the required material quantities.
3.  Verify that the generated material list correctly calculates `Target Quantity - Current Inventory`.
4.  Ensure both the configuration UI (`Configure.vue`) and the edit UI (`Edit.vue`) work properly.
5.  Check for type safety and ensure there are no compilation errors.

### **Commits**
* `eb95696107869aca71787c9f026281e0f9396f91` – feat(XIT ACT): add Stock material group
* `ada319ccc44ac839c781388bc14a0096c1345398` – refactor(XIT ACT): rename variable in stock.ts for consistency in material group