### PR TITLE
XIT ACT CX Sell

### DIFF
--- a/src/features/XIT/ACT/ACT.ts
+++ b/src/features/XIT/ACT/ACT.ts
@@ -1,4 +1,5 @@
 import './actions/cx-buy/cx-buy';
+import './actions/cx-sell/cx-sell';
 import './actions/mtra/mtra';
 import './actions/refuel/refuel';
 

--- a/src/features/XIT/ACT/action-steps/CXPO_SELL.ts
+++ b/src/features/XIT/ACT/action-steps/CXPO_SELL.ts
@@ -1,0 +1,181 @@
+import { act } from '@src/features/XIT/ACT/act-registry';
+import { fixed0, fixed02 } from '@src/utils/format';
+import { changeInputValue, clickElement } from '@src/util';
+import { fillAmount } from '@src/features/XIT/ACT/actions/cx-sell/utils';
+import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
+import { exchangesStore } from '@src/infrastructure/prun-api/data/exchanges';
+import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
+import { watchWhile } from '@src/utils/watch';
+import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
+import { watchEffect } from 'vue';
+import { AssertFn } from '@src/features/XIT/ACT/shared-types';
+
+interface Data {
+  exchange: string;
+  ticker: string;
+  amount: number;
+  priceLimit: number;
+  sellPartial: boolean;
+  allowUnfilled: boolean;
+}
+
+export const CXPO_SELL = act.addActionStep<Data>({
+  type: 'CXPO_SELL',
+  preProcessData: data => ({ ...data, ticker: data.ticker.toUpperCase() }),
+  description: data => {
+    const { ticker, exchange } = data;
+    const cxTicker = `${ticker}.${exchange}`;
+    const filled = fillAmount(cxTicker, data.amount, data.priceLimit);
+    const amount = filled?.amount ?? data.amount;
+    const priceLimit = filled?.priceLimit ?? data.priceLimit;
+    const allowUnfilled = data.allowUnfilled ?? false;
+    const willFillCompletely = filled && filled.amount === data.amount;
+
+    if (!willFillCompletely && allowUnfilled) {
+      let description = `Ask for ${fixed0(data.amount)} ${ticker} on ${exchange}`;
+      if (priceLimit > 0) {
+        description += ` at price ${fixed02(data.priceLimit)}`;
+      }
+      return description;
+    }
+
+    let description = `Sell ${fixed0(amount)} ${ticker} on ${exchange}`;
+    if (priceLimit > 0) {
+      description += ` with minimum price ${fixed02(priceLimit)}`;
+    }
+    if (filled) {
+      description += ` (${fixed0(filled.volume)} total value)`;
+    } else {
+      description += ' (no price data yet)';
+    }
+    return description;
+  },
+  execute: async ctx => {
+    const { data, log, setStatus, requestTile, waitAct, waitActionFeedback, complete, skip, fail } =
+      ctx;
+    const assert: AssertFn = ctx.assert;
+    const { amount, ticker, exchange, priceLimit } = data;
+    const cxTicker = `${ticker}.${exchange}`;
+    const cxWarehouse = computed(() => {
+      const naturalId = exchangesStore.getNaturalIdFromCode(exchange);
+      const warehouse = warehousesStore.getByEntityNaturalId(naturalId);
+      return storagesStore.getById(warehouse?.storeId);
+    });
+    assert(cxWarehouse.value, `CX warehouse not found for ${exchange}`);
+
+    if (amount <= 0) {
+      log.warning(`No ${ticker} was sold (target amount is 0)`);
+      skip();
+      return;
+    }
+
+    const material = materialsStore.getByTicker(ticker);
+    assert(material, `Unknown material ${ticker}`);
+
+    const availableAmount =
+      cxWarehouse.value.items
+        .map(x => x.quantity)
+        .find(x => x?.material.ticker === ticker)?.amount ?? 0;
+    assert(
+      availableAmount >= amount,
+      `Cannot sell ${fixed0(amount)} ${ticker} (only ${fixed0(availableAmount)} in warehouse)`,
+    );
+
+    const tile = await requestTile(`CXPO ${cxTicker}`);
+    if (!tile) {
+      return;
+    }
+
+    setStatus('Setting up CXPO buffer...');
+
+    const sellButton = await $(tile.anchor, C.Button.danger);
+    const form = await $(tile.anchor, C.ComExPlaceOrderForm.form);
+    const inputs = _$$(form, 'input');
+    const quantityInput = inputs[0];
+    assert(quantityInput !== undefined, 'Missing quantity input');
+    const priceInput = inputs[1];
+    assert(priceInput !== undefined, 'Missing price input');
+
+    let shouldUnwatch = false;
+    const unwatch = watchEffect(() => {
+      if (shouldUnwatch) {
+        unwatch();
+        return;
+      }
+
+      const filled = fillAmount(cxTicker, amount, priceLimit);
+
+      if (!filled) {
+        shouldUnwatch = true;
+        fail(`Missing ${cxTicker} order book data`);
+        return;
+      }
+
+      if (filled.amount < amount && !data.allowUnfilled) {
+        if (!data.sellPartial) {
+          let message = `Not enough demand on ${exchange} to sell ${fixed0(amount)} ${ticker}`;
+          if (priceLimit > 0) {
+            message += ` with minimum price ${fixed02(priceLimit)}/u`;
+          }
+          shouldUnwatch = true;
+          fail(message);
+          return;
+        }
+
+        const leftover = amount - filled.amount;
+        let message =
+          `${fixed0(leftover)} ${ticker} will not be sold on ${exchange} ` +
+          `(${fixed0(filled.amount)} of ${fixed0(amount)} demand available`;
+        if (priceLimit > 0) {
+          message += ` with minimum price ${fixed02(priceLimit)}/u`;
+        }
+        message += ')';
+        log.warning(message);
+        if (filled.amount === 0) {
+          shouldUnwatch = true;
+          skip();
+          return;
+        }
+      }
+
+      if (data.allowUnfilled) {
+        changeInputValue(quantityInput, data.amount.toString());
+        changeInputValue(priceInput, fixed02(data.priceLimit));
+      } else {
+        changeInputValue(quantityInput, filled.amount.toString());
+        changeInputValue(priceInput, fixed02(filled.priceLimit));
+      }
+
+      // Cache description before clicking the sell button because
+      // order book data will change after that.
+      ctx.cacheDescription();
+    });
+
+    await waitAct();
+    unwatch();
+
+    const warehouseAmount = computed(() => {
+      return (
+        cxWarehouse.value?.items
+          .map(x => x.quantity ?? undefined)
+          .filter(x => x !== undefined)
+          .find(x => x.material.ticker === ticker)?.amount ?? 0
+      );
+    });
+    const currentAmount = warehouseAmount.value;
+    const amountToFill = fillAmount(cxTicker, amount, priceLimit)?.amount ?? 0;
+    const shouldWaitForUpdate = amountToFill > 0;
+
+    await clickElement(sellButton);
+    await waitActionFeedback(tile);
+
+    if (shouldWaitForUpdate) {
+      setStatus('Waiting for storage update...');
+      await watchWhile(() => warehouseAmount.value === currentAmount);
+    } else {
+      setStatus('Ask order created');
+    }
+
+    complete();
+  },
+});

--- a/src/features/XIT/ACT/action-steps/CXPO_SELL.ts
+++ b/src/features/XIT/ACT/action-steps/CXPO_SELL.ts
@@ -35,6 +35,7 @@ export const CXPO_SELL = act.addActionStep<Data>({
       let description = `Ask for ${fixed0(data.amount)} ${ticker} on ${exchange}`;
       if (priceLimit > 0) {
         description += ` at price ${fixed02(data.priceLimit)}`;
+        description += ` (${fixed0(data.amount * data.priceLimit)} total value)`;
       }
       return description;
     }

--- a/src/features/XIT/ACT/action-steps/CXPO_SELL.ts
+++ b/src/features/XIT/ACT/action-steps/CXPO_SELL.ts
@@ -155,7 +155,19 @@ export const CXPO_SELL = act.addActionStep<Data>({
       ctx.cacheDescription();
     });
 
+    function onManualInput(event: Event) {
+      // Synthetic events from changeInputValue() have isTrusted === false.
+      if (event.isTrusted && !shouldUnwatch) {
+        shouldUnwatch = true;
+        log.info('Manual input detected; keeping user-entered quantity and price');
+      }
+    }
+    quantityInput.addEventListener('input', onManualInput);
+    priceInput.addEventListener('input', onManualInput);
+
     await waitAct();
+    quantityInput.removeEventListener('input', onManualInput);
+    priceInput.removeEventListener('input', onManualInput);
     unwatch();
 
     const originAmount = computed(() => {

--- a/src/features/XIT/ACT/action-steps/CXPO_SELL.ts
+++ b/src/features/XIT/ACT/action-steps/CXPO_SELL.ts
@@ -1,10 +1,8 @@
 import { act } from '@src/features/XIT/ACT/act-registry';
 import { fixed0, fixed02 } from '@src/utils/format';
-import { changeInputValue, clickElement } from '@src/util';
+import { changeInputValue, changeSelectIndex, clickElement } from '@src/util';
 import { fillAmount } from '@src/features/XIT/ACT/actions/cx-sell/utils';
 import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
-import { exchangesStore } from '@src/infrastructure/prun-api/data/exchanges';
-import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
 import { watchWhile } from '@src/utils/watch';
 import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
 import { watchEffect } from 'vue';
@@ -12,6 +10,7 @@ import { AssertFn } from '@src/features/XIT/ACT/shared-types';
 
 interface Data {
   exchange: string;
+  originId?: string;
   ticker: string;
   amount: number;
   priceLimit: number;
@@ -57,12 +56,8 @@ export const CXPO_SELL = act.addActionStep<Data>({
     const assert: AssertFn = ctx.assert;
     const { amount, ticker, exchange, priceLimit } = data;
     const cxTicker = `${ticker}.${exchange}`;
-    const cxWarehouse = computed(() => {
-      const naturalId = exchangesStore.getNaturalIdFromCode(exchange);
-      const warehouse = warehousesStore.getByEntityNaturalId(naturalId);
-      return storagesStore.getById(warehouse?.storeId);
-    });
-    assert(cxWarehouse.value, `CX warehouse not found for ${exchange}`);
+    const origin = computed(() => storagesStore.getById(data.originId));
+    assert(origin.value, 'Origin inventory not found');
 
     if (amount <= 0) {
       log.warning(`No ${ticker} was sold (target amount is 0)`);
@@ -74,12 +69,12 @@ export const CXPO_SELL = act.addActionStep<Data>({
     assert(material, `Unknown material ${ticker}`);
 
     const availableAmount =
-      cxWarehouse.value.items
+      origin.value.items
         .map(x => x.quantity)
         .find(x => x?.material.ticker === ticker)?.amount ?? 0;
     assert(
       availableAmount >= amount,
-      `Cannot sell ${fixed0(amount)} ${ticker} (only ${fixed0(availableAmount)} in warehouse)`,
+      `Cannot sell ${fixed0(amount)} ${ticker} (only ${fixed0(availableAmount)} in origin)`,
     );
 
     const tile = await requestTile(`CXPO ${cxTicker}`);
@@ -91,6 +86,14 @@ export const CXPO_SELL = act.addActionStep<Data>({
 
     const sellButton = await $(tile.anchor, C.Button.danger);
     const form = await $(tile.anchor, C.ComExPlaceOrderForm.form);
+
+    const storageLocation = await $(form, 'select');
+    const originIndex = Array.from(storageLocation.options).findIndex(
+      opt => opt.value === origin.value!.id,
+    );
+    assert(originIndex >= 0, 'Origin storage location not found in CXPO form');
+    changeSelectIndex(storageLocation, originIndex);
+
     const inputs = _$$(form, 'input');
     const quantityInput = inputs[0];
     assert(quantityInput !== undefined, 'Missing quantity input');
@@ -155,15 +158,15 @@ export const CXPO_SELL = act.addActionStep<Data>({
     await waitAct();
     unwatch();
 
-    const warehouseAmount = computed(() => {
+    const originAmount = computed(() => {
       return (
-        cxWarehouse.value?.items
+        origin.value?.items
           .map(x => x.quantity ?? undefined)
           .filter(x => x !== undefined)
           .find(x => x.material.ticker === ticker)?.amount ?? 0
       );
     });
-    const currentAmount = warehouseAmount.value;
+    const currentAmount = originAmount.value;
     const amountToFill = fillAmount(cxTicker, amount, priceLimit)?.amount ?? 0;
     const shouldWaitForUpdate = amountToFill > 0;
 
@@ -172,7 +175,7 @@ export const CXPO_SELL = act.addActionStep<Data>({
 
     if (shouldWaitForUpdate) {
       setStatus('Waiting for storage update...');
-      await watchWhile(() => warehouseAmount.value === currentAmount);
+      await watchWhile(() => originAmount.value === currentAmount);
     } else {
       setStatus('Ask order created');
     }

--- a/src/features/XIT/ACT/actions/cx-sell/Configure.vue
+++ b/src/features/XIT/ACT/actions/cx-sell/Configure.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import Active from '@src/components/forms/Active.vue';
+import SelectInput from '@src/components/forms/SelectInput.vue';
+import { Config } from '@src/features/XIT/ACT/actions/cx-sell/config';
+import {
+  atSameLocation,
+  deserializeStorage,
+  serializeStorage,
+  storageSort,
+} from '@src/features/XIT/ACT/actions/utils';
+import { configurableValue } from '@src/features/XIT/ACT/shared-types';
+import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
+import { exchangesStore } from '@src/infrastructure/prun-api/data/exchanges';
+import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
+
+const { data, config } = defineProps<{ data: UserData.ActionData; config: Config }>();
+
+const cxWarehouse = computed(() => {
+  const exchange = data.exchange;
+  if (!exchange) {
+    return undefined;
+  }
+
+  const naturalId = exchangesStore.getNaturalIdFromCode(exchange);
+  const warehouse = warehousesStore.getByEntityNaturalId(naturalId);
+  return storagesStore.getById(warehouse?.storeId);
+});
+
+const originStorages = computed(() => {
+  const warehouse = cxWarehouse.value;
+  if (!warehouse) {
+    return [];
+  }
+
+  return (storagesStore.nonFuelStores.value ?? [])
+    .filter(x => atSameLocation(x, warehouse))
+    .sort(storageSort);
+});
+
+const originOptions = computed(() => getOptions(originStorages.value));
+
+if (data.origin === configurableValue && !config.origin && originStorages.value.length > 0) {
+  config.origin = serializeStorage(originStorages.value[0]);
+}
+
+// Autofill and autofix selections on storage list change.
+watchEffect(() => {
+  if (data.origin !== configurableValue) {
+    return;
+  }
+
+  if (config.origin) {
+    const origin = deserializeStorage(config.origin);
+    if (!origin || !originStorages.value.includes(origin)) {
+      config.origin = undefined;
+    }
+  }
+
+  if (!config.origin && originStorages.value.length === 1) {
+    config.origin = serializeStorage(originStorages.value[0]);
+  }
+});
+
+function getOptions(storages: PrunApi.Store[]) {
+  const options = storages.map(serializeStorage).map(x => ({ label: x, value: x }));
+  if (options.length === 0) {
+    options.push({ label: 'No locations available', value: undefined! });
+  }
+  return options;
+}
+</script>
+
+<template>
+  <form>
+    <Active label="From">
+      <SelectInput v-model="config.origin" :options="originOptions" />
+    </Active>
+  </form>
+</template>

--- a/src/features/XIT/ACT/actions/cx-sell/Edit.vue
+++ b/src/features/XIT/ACT/actions/cx-sell/Edit.vue
@@ -63,7 +63,7 @@ defineExpose({ validate, save });
   <Active label="Exchange">
     <SelectInput v-model="exchange" :options="exchanges" />
   </Active>
-  <Commands label="Minimum Prices">
+  <Commands label="Price Limits">
     <PrunButton primary @click="onEditPriceLimitsClick">EDIT</PrunButton>
   </Commands>
   <Active

--- a/src/features/XIT/ACT/actions/cx-sell/Edit.vue
+++ b/src/features/XIT/ACT/actions/cx-sell/Edit.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import Active from '@src/components/forms/Active.vue';
+import Commands from '@src/components/forms/Commands.vue';
+import PrunButton from '@src/components/PrunButton.vue';
+import SelectInput from '@src/components/forms/SelectInput.vue';
+import RadioItem from '@src/components/forms/RadioItem.vue';
+import { showTileOverlay } from '@src/infrastructure/prun-ui/tile-overlay';
+import EditPriceLimits from '@src/features/XIT/ACT/actions/cx-buy/EditPriceLimits.vue';
+import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
+
+const { action, pkg } = defineProps<{
+  action: UserData.ActionData;
+  pkg: UserData.ActionPackageData;
+}>();
+
+const materialGroups = computed(() => pkg.groups.map(x => x.name!).filter(x => x));
+const materialGroup = ref(action.group ?? materialGroups.value[0]);
+
+const exchanges = ['AI1', 'CI1', 'IC1', 'NC1', 'CI2', 'NC2'];
+const exchange = ref(action.exchange ?? exchanges[0]);
+
+const priceLimits = ref(getPriceLimits());
+
+function getPriceLimits() {
+  const priceLimits = action.priceLimits ?? {};
+  return Object.keys(priceLimits).map(x => [x, priceLimits[x]]) as [string, number][];
+}
+
+const sellPartial = ref(action.sellPartial ?? false);
+
+const allowUnfilled = ref(action.allowUnfilled ?? false);
+
+function onEditPriceLimitsClick(e: Event) {
+  showTileOverlay(e, EditPriceLimits, reactive({ priceLimits }));
+}
+
+function validate() {
+  return true;
+}
+
+function save() {
+  action.group = materialGroup.value;
+  action.exchange = exchange.value;
+  action.priceLimits = {};
+  for (let [ticker, price] of priceLimits.value) {
+    const material = materialsStore.getByTicker(ticker);
+    if (!material || price === 0 || !isFinite(price)) {
+      continue;
+    }
+    action.priceLimits[material.ticker] = price;
+  }
+  action.sellPartial = sellPartial.value;
+  action.allowUnfilled = allowUnfilled.value;
+}
+
+defineExpose({ validate, save });
+</script>
+
+<template>
+  <Active label="Material Group">
+    <SelectInput v-model="materialGroup" :options="materialGroups" />
+  </Active>
+  <Active label="Exchange">
+    <SelectInput v-model="exchange" :options="exchanges" />
+  </Active>
+  <Commands label="Minimum Prices">
+    <PrunButton primary @click="onEditPriceLimitsClick">EDIT</PrunButton>
+  </Commands>
+  <Active
+    label="Sell Partial"
+    tooltip="Whether the action will be taken if there is not enough demand on the CX.">
+    <RadioItem v-model="sellPartial">sell partial</RadioItem>
+  </Active>
+  <Active
+    label="Allow Unfilled"
+    tooltip="Create a full ask order even if there is not enough demand on the CX.">
+    <RadioItem v-model="allowUnfilled">allow unfilled</RadioItem>
+  </Active>
+</template>

--- a/src/features/XIT/ACT/actions/cx-sell/Edit.vue
+++ b/src/features/XIT/ACT/actions/cx-sell/Edit.vue
@@ -7,6 +7,15 @@ import RadioItem from '@src/components/forms/RadioItem.vue';
 import { showTileOverlay } from '@src/infrastructure/prun-ui/tile-overlay';
 import EditPriceLimits from '@src/features/XIT/ACT/actions/cx-buy/EditPriceLimits.vue';
 import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
+import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
+import { exchangesStore } from '@src/infrastructure/prun-api/data/exchanges';
+import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
+import {
+  atSameLocation,
+  serializeStorage,
+  storageSort,
+} from '@src/features/XIT/ACT/actions/utils';
+import { configurableValue } from '@src/features/XIT/ACT/shared-types';
 
 const { action, pkg } = defineProps<{
   action: UserData.ActionData;
@@ -18,6 +27,42 @@ const materialGroup = ref(action.group ?? materialGroups.value[0]);
 
 const exchanges = ['AI1', 'CI1', 'IC1', 'NC1', 'CI2', 'NC2'];
 const exchange = ref(action.exchange ?? exchanges[0]);
+
+const cxWarehouse = computed(() => {
+  const naturalId = exchangesStore.getNaturalIdFromCode(exchange.value);
+  const warehouse = warehousesStore.getByEntityNaturalId(naturalId);
+  return storagesStore.getById(warehouse?.storeId);
+});
+
+const originStorages = computed(() => {
+  const warehouse = cxWarehouse.value;
+  if (!warehouse) {
+    return [];
+  }
+
+  return (storagesStore.nonFuelStores.value ?? [])
+    .filter(x => atSameLocation(x, warehouse))
+    .sort(storageSort)
+    .map(serializeStorage);
+});
+
+const originOptions = computed(() => {
+  const options = [...originStorages.value];
+  options.unshift(configurableValue);
+  return options;
+});
+
+const origin = ref(action.origin ?? originStorages.value[0] ?? originOptions.value[0]);
+
+watchEffect(() => {
+  if (origin.value === configurableValue) {
+    return;
+  }
+
+  if (!originStorages.value.includes(origin.value)) {
+    origin.value = originStorages.value[0] ?? configurableValue;
+  }
+});
 
 const priceLimits = ref(getPriceLimits());
 
@@ -41,6 +86,7 @@ function validate() {
 function save() {
   action.group = materialGroup.value;
   action.exchange = exchange.value;
+  action.origin = origin.value;
   action.priceLimits = {};
   for (let [ticker, price] of priceLimits.value) {
     const material = materialsStore.getByTicker(ticker);
@@ -62,6 +108,9 @@ defineExpose({ validate, save });
   </Active>
   <Active label="Exchange">
     <SelectInput v-model="exchange" :options="exchanges" />
+  </Active>
+  <Active label="Origin">
+    <SelectInput v-model="origin" :options="originOptions" />
   </Active>
   <Commands label="Price Limits">
     <PrunButton primary @click="onEditPriceLimitsClick">EDIT</PrunButton>

--- a/src/features/XIT/ACT/actions/cx-sell/config.ts
+++ b/src/features/XIT/ACT/actions/cx-sell/config.ts
@@ -1,0 +1,3 @@
+export interface Config {
+  origin?: string;
+}

--- a/src/features/XIT/ACT/actions/cx-sell/cx-sell.ts
+++ b/src/features/XIT/ACT/actions/cx-sell/cx-sell.ts
@@ -1,0 +1,80 @@
+import { act } from '@src/features/XIT/ACT/act-registry';
+import Edit from '@src/features/XIT/ACT/actions/cx-sell/Edit.vue';
+import { CXPO_SELL } from '@src/features/XIT/ACT/action-steps/CXPO_SELL';
+import { fixed0, fixed02 } from '@src/utils/format';
+import { fillAmount } from '@src/features/XIT/ACT/actions/cx-sell/utils';
+import { AssertFn } from '@src/features/XIT/ACT/shared-types';
+
+act.addAction({
+  type: 'CX Sell',
+  description: action => {
+    if (!action.group || !action.exchange) {
+      return '--';
+    }
+
+    return 'Selling group ' + action.group + ' on ' + action.exchange;
+  },
+  editComponent: Edit,
+  generateSteps: async ctx => {
+    const { data, log, fail, getMaterialGroup, emitStep } = ctx;
+    const assert: AssertFn = ctx.assert;
+    const allowUnfilled = data.allowUnfilled ?? false;
+    const sellPartial = data.sellPartial ?? false;
+
+    const materials = await getMaterialGroup(data.group);
+    assert(materials, 'Invalid material group');
+
+    const exchange = data.exchange;
+    assert(exchange, 'Missing exchange');
+
+    for (const ticker of Object.keys(materials)) {
+      const amount = materials[ticker];
+      const priceLimit = data.priceLimits?.[ticker] ?? 0;
+      if (isNaN(priceLimit)) {
+        log.error('Non-numerical price limit on ' + ticker);
+        continue;
+      }
+
+      const cxTicker = `${ticker}.${data.exchange}`;
+      const filled = fillAmount(cxTicker, amount, priceLimit);
+      let askAmount = amount;
+
+      if (filled && filled.amount < amount && !allowUnfilled) {
+        if (!sellPartial) {
+          let message = `Not enough demand on ${exchange} to sell ${fixed0(amount)} ${ticker}`;
+          if (priceLimit > 0) {
+            message += ` with minimum price ${fixed02(priceLimit)}/u`;
+          }
+          fail(message);
+          return;
+        }
+
+        const leftover = amount - filled.amount;
+        let message =
+          `${fixed0(leftover)} ${ticker} will not be sold on ${exchange} ` +
+          `(${fixed0(filled.amount)} of ${fixed0(amount)} demand available`;
+        if (priceLimit > 0) {
+          message += ` with minimum price ${fixed02(priceLimit)}/u`;
+        }
+        message += ')';
+        log.warning(message);
+        if (filled.amount === 0) {
+          continue;
+        }
+
+        askAmount = filled.amount;
+      }
+
+      emitStep(
+        CXPO_SELL({
+          exchange,
+          ticker,
+          amount: askAmount,
+          priceLimit,
+          sellPartial,
+          allowUnfilled,
+        }),
+      );
+    }
+  },
+});

--- a/src/features/XIT/ACT/actions/cx-sell/cx-sell.ts
+++ b/src/features/XIT/ACT/actions/cx-sell/cx-sell.ts
@@ -1,22 +1,46 @@
 import { act } from '@src/features/XIT/ACT/act-registry';
 import Edit from '@src/features/XIT/ACT/actions/cx-sell/Edit.vue';
+import Configure from '@src/features/XIT/ACT/actions/cx-sell/Configure.vue';
+import { Config } from '@src/features/XIT/ACT/actions/cx-sell/config';
 import { CXPO_SELL } from '@src/features/XIT/ACT/action-steps/CXPO_SELL';
 import { fixed0, fixed02 } from '@src/utils/format';
 import { fillAmount } from '@src/features/XIT/ACT/actions/cx-sell/utils';
-import { AssertFn } from '@src/features/XIT/ACT/shared-types';
+import { AssertFn, configurableValue } from '@src/features/XIT/ACT/shared-types';
+import {
+  atSameLocation,
+  deserializeStorage,
+  serializeStorage,
+} from '@src/features/XIT/ACT/actions/utils';
+import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
+import { exchangesStore } from '@src/infrastructure/prun-api/data/exchanges';
+import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
 
-act.addAction({
+act.addAction<Config>({
   type: 'CX Sell',
-  description: action => {
+  description: (action, config) => {
     if (!action.group || !action.exchange) {
       return '--';
     }
 
-    return 'Selling group ' + action.group + ' on ' + action.exchange;
+    let origin = 'CX warehouse';
+    if (action.origin === configurableValue) {
+      origin = config?.origin ?? 'configured location';
+    } else if (action.origin) {
+      origin = action.origin;
+    }
+
+    return `Selling group ${action.group} on ${action.exchange} from ${origin}`;
   },
   editComponent: Edit,
+  configureComponent: Configure,
+  needsConfigure: data => {
+    return data.origin === configurableValue;
+  },
+  isValidConfig: (data, config) => {
+    return data.origin !== configurableValue || config.origin !== undefined;
+  },
   generateSteps: async ctx => {
-    const { data, log, fail, getMaterialGroup, emitStep } = ctx;
+    const { data, config, log, fail, getMaterialGroup, emitStep } = ctx;
     const assert: AssertFn = ctx.assert;
     const allowUnfilled = data.allowUnfilled ?? false;
     const sellPartial = data.sellPartial ?? false;
@@ -26,6 +50,19 @@ act.addAction({
 
     const exchange = data.exchange;
     assert(exchange, 'Missing exchange');
+
+    let serializedOrigin = data.origin;
+    if (!serializedOrigin) {
+      const naturalId = exchangesStore.getNaturalIdFromCode(exchange);
+      const warehouse = warehousesStore.getByEntityNaturalId(naturalId);
+      const cxWarehouse = storagesStore.getById(warehouse?.storeId);
+      assert(cxWarehouse, `CX warehouse not found for ${exchange}`);
+      serializedOrigin = serializeStorage(cxWarehouse);
+    } else if (serializedOrigin === configurableValue) {
+      serializedOrigin = config?.origin;
+    }
+    const origin = deserializeStorage(serializedOrigin);
+    assert(origin, 'Invalid origin');
 
     for (const ticker of Object.keys(materials)) {
       const amount = materials[ticker];
@@ -68,6 +105,7 @@ act.addAction({
       emitStep(
         CXPO_SELL({
           exchange,
+          originId: origin.id,
           ticker,
           amount: askAmount,
           priceLimit,

--- a/src/features/XIT/ACT/actions/cx-sell/utils.ts
+++ b/src/features/XIT/ACT/actions/cx-sell/utils.ts
@@ -1,0 +1,33 @@
+import { cxobStore } from '@src/infrastructure/prun-api/data/cxob';
+import { isFiniteOrder } from '@src/core/orders';
+
+export function fillAmount(cxTicker: string, amount: number, priceLimit: number) {
+  const orderBook = cxobStore.getByTicker(cxTicker);
+  if (!orderBook) {
+    return undefined;
+  }
+
+  const filled = {
+    amount: 0,
+    priceLimit: 0,
+    volume: 0,
+  };
+  const orders = orderBook.buyingOrders.slice().sort((a, b) => b.limit.amount - a.limit.amount);
+  for (const order of orders) {
+    const orderPrice = order.limit.amount;
+    if (priceLimit > orderPrice) {
+      break;
+    }
+    const orderAmount = isFiniteOrder(order) ? order.amount : Infinity;
+    const remaining = amount - filled.amount;
+    const filledByOrder = Math.min(remaining, orderAmount);
+    filled.priceLimit = orderPrice;
+    filled.amount += filledByOrder;
+    filled.volume += filledByOrder * orderPrice;
+    if (filled.amount === amount) {
+      break;
+    }
+  }
+
+  return filled;
+}

--- a/src/store/user-data.types.d.ts
+++ b/src/store/user-data.types.d.ts
@@ -62,7 +62,7 @@ declare namespace UserData {
     consumablesOnly?: boolean;
   }
 
-  type ActionType = 'CX Buy' | 'MTRA' | 'Refuel';
+  type ActionType = 'CX Buy' | 'CX Sell' | 'MTRA' | 'Refuel';
 
   interface ActionData {
     type: ActionType;
@@ -72,6 +72,7 @@ declare namespace UserData {
 
     allowUnfilled?: boolean;
     buyPartial?: boolean;
+    sellPartial?: boolean;
     exchange?: string;
     useCXInv?: boolean;
     priceLimits?: Record<string, number>;


### PR DESCRIPTION
Add a new XIT ACT action type that sells things instead of buying them.

The only sensible material group to use for this is probably manual.
I plan to write some code to look at the inventory of ships that just landed at CX
and figure out what to sell vs keep, then generate a CX Sell action.