### PR TITLE
Add ACT button to BURN for one-click planet resupply

### DIFF
--- a/src/features/XIT/ACT/actions/cx-buy/Configure.vue
+++ b/src/features/XIT/ACT/actions/cx-buy/Configure.vue
@@ -7,9 +7,7 @@ const { config } = defineProps<{ data: UserData.ActionData; config: Config }>();
 
 const exchanges = ['AI1', 'CI1', 'IC1', 'NC1', 'CI2', 'NC2'];
 
-if (!config.exchange) {
-  config.exchange = exchanges[0];
-}
+config.exchange ??= exchanges[0];
 </script>
 
 <template>

--- a/src/features/XIT/ACT/actions/cx-buy/Configure.vue
+++ b/src/features/XIT/ACT/actions/cx-buy/Configure.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import Active from '@src/components/forms/Active.vue';
+import SelectInput from '@src/components/forms/SelectInput.vue';
+import { Config } from '@src/features/XIT/ACT/actions/cx-buy/config';
+
+const { config } = defineProps<{ data: UserData.ActionData; config: Config }>();
+
+const exchanges = ['AI1', 'CI1', 'IC1', 'NC1', 'CI2', 'NC2'];
+
+if (!config.exchange) {
+  config.exchange = exchanges[0];
+}
+</script>
+
+<template>
+  <form>
+    <Active label="Exchange">
+      <SelectInput v-model="config.exchange" :options="exchanges" />
+    </Active>
+  </form>
+</template>

--- a/src/features/XIT/ACT/actions/cx-buy/Edit.vue
+++ b/src/features/XIT/ACT/actions/cx-buy/Edit.vue
@@ -7,6 +7,7 @@ import RadioItem from '@src/components/forms/RadioItem.vue';
 import { showTileOverlay } from '@src/infrastructure/prun-ui/tile-overlay';
 import EditPriceLimits from '@src/features/XIT/ACT/actions/cx-buy/EditPriceLimits.vue';
 import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
+import { configurableValue } from '@src/features/XIT/ACT/shared-types';
 
 const { action, pkg } = defineProps<{
   action: UserData.ActionData;
@@ -16,7 +17,7 @@ const { action, pkg } = defineProps<{
 const materialGroups = computed(() => pkg.groups.map(x => x.name!).filter(x => x));
 const materialGroup = ref(action.group ?? materialGroups.value[0]);
 
-const exchanges = ['AI1', 'CI1', 'IC1', 'NC1', 'CI2', 'NC2'];
+const exchanges = [configurableValue, 'AI1', 'CI1', 'IC1', 'NC1', 'CI2', 'NC2'];
 const exchange = ref(action.exchange ?? exchanges[0]);
 
 const priceLimits = ref(getPriceLimits());

--- a/src/features/XIT/ACT/actions/cx-buy/config.ts
+++ b/src/features/XIT/ACT/actions/cx-buy/config.ts
@@ -1,0 +1,3 @@
+export interface Config {
+  exchange?: string;
+}

--- a/src/features/XIT/ACT/actions/cx-buy/cx-buy.ts
+++ b/src/features/XIT/ACT/actions/cx-buy/cx-buy.ts
@@ -1,22 +1,32 @@
 import { act } from '@src/features/XIT/ACT/act-registry';
 import Edit from '@src/features/XIT/ACT/actions/cx-buy/Edit.vue';
+import Configure from '@src/features/XIT/ACT/actions/cx-buy/Configure.vue';
+import { Config } from '@src/features/XIT/ACT/actions/cx-buy/config';
 import { CXPO_BUY } from '@src/features/XIT/ACT/action-steps/CXPO_BUY';
 import { fixed0, fixed02 } from '@src/utils/format';
 import { fillAmount } from '@src/features/XIT/ACT/actions/cx-buy/utils';
-import { AssertFn } from '@src/features/XIT/ACT/shared-types';
+import { AssertFn, configurableValue } from '@src/features/XIT/ACT/shared-types';
 
-act.addAction({
+act.addAction<Config>({
   type: 'CX Buy',
-  description: action => {
+  description: (action, config) => {
     if (!action.group || !action.exchange) {
       return '--';
     }
 
-    return 'Buying group ' + action.group + ' from ' + action.exchange;
+    const exchange =
+      action.exchange === configurableValue
+        ? (config?.exchange ?? 'configured exchange')
+        : action.exchange;
+    return 'Buying group ' + action.group + ' from ' + exchange;
   },
   editComponent: Edit,
+  configureComponent: Configure,
+  needsConfigure: data => data.exchange === configurableValue,
+  isValidConfig: (data, config) =>
+    data.exchange !== configurableValue || config.exchange !== undefined,
   generateSteps: async ctx => {
-    const { data, state, log, fail, getMaterialGroup, emitStep } = ctx;
+    const { data, config, state, log, fail, getMaterialGroup, emitStep } = ctx;
     const assert: AssertFn = ctx.assert;
     const allowUnfilled = data.allowUnfilled ?? false;
     const buyPartial = data.buyPartial ?? false;
@@ -24,21 +34,21 @@ act.addAction({
     const materials = await getMaterialGroup(data.group);
     assert(materials, 'Invalid material group');
 
-    const exchange = data.exchange;
+    const exchange = data.exchange === configurableValue ? config.exchange : data.exchange;
     assert(exchange, 'Missing exchange');
 
     // Take out materials in CX inventory if requested
-    if ((data.useCXInv ?? true) && data.exchange) {
+    if ((data.useCXInv ?? true) && exchange) {
       for (const mat of Object.keys(materials)) {
-        for (const CXMat of Object.keys(state.WAR[data.exchange])) {
+        for (const CXMat of Object.keys(state.WAR[exchange])) {
           if (CXMat === mat) {
             // Amount of material used (minimum of needed and had on hand)
-            const used = Math.min(materials[mat], state.WAR[data.exchange][CXMat]);
+            const used = Math.min(materials[mat], state.WAR[exchange][CXMat]);
             materials[mat] -= used;
-            state.WAR[data.exchange][CXMat] -= used;
-            if (state.WAR[data.exchange][mat] <= 0) {
+            state.WAR[exchange][CXMat] -= used;
+            if (state.WAR[exchange][mat] <= 0) {
               // Remove material from CX Inv is already allocated
-              delete state.WAR[data.exchange][CXMat];
+              delete state.WAR[exchange][CXMat];
             }
           }
         }
@@ -57,7 +67,7 @@ act.addAction({
         continue;
       }
 
-      const cxTicker = `${ticker}.${data.exchange}`;
+      const cxTicker = `${ticker}.${exchange}`;
       const filled = fillAmount(cxTicker, amount, priceLimit);
       let bidAmount = amount;
 

--- a/src/features/XIT/ACT/material-groups/resupply/Configure.vue
+++ b/src/features/XIT/ACT/material-groups/resupply/Configure.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
 import SelectInput from '@src/components/forms/SelectInput.vue';
 import Active from '@src/components/forms/Active.vue';
+import NumberInput from '@src/components/forms/NumberInput.vue';
 import { Config } from '@src/features/XIT/ACT/material-groups/resupply/config';
 import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
 import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses';
 import { comparePlanets } from '@src/util';
+import { configurableValue } from '@src/features/XIT/ACT/shared-types';
+import { userData } from '@src/store/user-data';
 
-const { config } = defineProps<{ data: UserData.ActionData; config: Config }>();
+const { data, config } = defineProps<{ data: UserData.MaterialGroupData; config: Config }>();
 
 const planets = computed(() =>
   (sitesStore.all.value ?? [])
@@ -15,15 +18,25 @@ const planets = computed(() =>
     .sort(comparePlanets),
 );
 
-if (!config.planet) {
+if (data.planet === configurableValue && !config.planet) {
   config.planet = planets.value[0];
+}
+
+if (data.days === configurableValue && config.days === undefined) {
+  config.days = userData.settings.burn.resupply ?? 10;
 }
 </script>
 
 <template>
   <form>
-    <Active label="Planet">
+    <Active v-if="data.planet === configurableValue" label="Planet">
       <SelectInput v-model="config.planet" :options="planets" />
+    </Active>
+    <Active
+      v-if="data.days === configurableValue"
+      label="Days"
+      tooltip="The number of days of supplies to refill the planet with.">
+      <NumberInput v-model="config.days" />
     </Active>
   </form>
 </template>

--- a/src/features/XIT/ACT/material-groups/resupply/Edit.vue
+++ b/src/features/XIT/ACT/material-groups/resupply/Edit.vue
@@ -24,8 +24,13 @@ const planets = computed(() => {
 const planet = ref(group.planet ?? planets.value[0]);
 const planetError = ref(false);
 
+const configureDaysOnExecution = ref(group.days === configurableValue);
 const days = ref(
-  typeof group.days === 'string' ? parseInt(group.days || '10') : (group.days ?? 10),
+  typeof group.days === 'string' && group.days !== configurableValue
+    ? parseInt(group.days || '10')
+    : typeof group.days === 'number'
+      ? group.days
+      : 10,
 );
 const daysError = ref(false);
 
@@ -39,14 +44,14 @@ function validate() {
   let isValid = true;
   planetError.value = !planet.value;
   isValid &&= !planetError.value;
-  daysError.value = days.value <= 0;
+  daysError.value = !configureDaysOnExecution.value && days.value <= 0;
   isValid &&= !daysError.value;
   return isValid;
 }
 
 function save() {
   group.planet = planet.value;
-  group.days = days.value;
+  group.days = configureDaysOnExecution.value ? configurableValue : days.value;
   group.exclusions = exclusions.value
     .split(',')
     .map(x => materialsStore.getByTicker(x.trim())?.ticker)
@@ -66,7 +71,8 @@ defineExpose({ validate, save });
     label="Days"
     tooltip="The number of days of supplies to refill the planet with."
     :error="daysError">
-    <NumberInput v-model="days" />
+    <NumberInput v-if="!configureDaysOnExecution" v-model="days" />
+    <RadioItem v-model="configureDaysOnExecution">configure on execution</RadioItem>
   </Active>
   <Active
     label="Material Exclusions"

--- a/src/features/XIT/ACT/material-groups/resupply/config.ts
+++ b/src/features/XIT/ACT/material-groups/resupply/config.ts
@@ -1,3 +1,4 @@
 export interface Config {
   planet: string;
+  days?: number;
 }

--- a/src/features/XIT/ACT/material-groups/resupply/resupply.ts
+++ b/src/features/XIT/ACT/material-groups/resupply/resupply.ts
@@ -21,7 +21,8 @@ act.addMaterialGroup<Config>({
       return '--';
     }
 
-    return `Resupply ${data.planet} with ${data.days} day${data.days == 1 ? '' : 's'} of supplies`;
+    const daysLabel = data.days === configurableValue ? '?' : data.days;
+    return `Resupply ${data.planet} with ${daysLabel} day${data.days == 1 ? '' : 's'} of supplies`;
   },
   editComponent: Edit,
   configureComponent: Configure,

--- a/src/features/XIT/ACT/material-groups/resupply/resupply.ts
+++ b/src/features/XIT/ACT/material-groups/resupply/resupply.ts
@@ -25,8 +25,10 @@ act.addMaterialGroup<Config>({
   },
   editComponent: Edit,
   configureComponent: Configure,
-  needsConfigure: data => data.planet === configurableValue,
-  isValidConfig: (data, config) => data.planet !== configurableValue || config.planet !== undefined,
+  needsConfigure: data => data.planet === configurableValue || data.days === configurableValue,
+  isValidConfig: (data, config) =>
+    (data.planet !== configurableValue || config.planet !== undefined) &&
+    (data.days !== configurableValue || config.days !== undefined),
   generateMaterialBill: async ({ data, config, log, setStatus }) => {
     if (!data.planet) {
       log.error('Missing resupply planet');
@@ -37,12 +39,18 @@ act.addMaterialGroup<Config>({
 
     const exclusions = data.exclusions ?? [];
     const planet = data.planet === configurableValue ? config.planet : data.planet;
+    const days =
+      data.days === configurableValue
+        ? (config.days ?? 10)
+        : typeof data.days === 'number'
+          ? data.days
+          : parseFloat(data.days as string);
     const site = sitesStore.getByPlanetNaturalIdOrName(planet);
     if (!site) {
       log.error(`Base is not present on ${data.planet}`);
     }
 
-    if (!site || data.days === undefined) {
+    if (!site || days === undefined || isNaN(days)) {
       return undefined;
     }
 
@@ -73,8 +81,8 @@ act.addMaterialGroup<Config>({
       if (matBurn.dailyAmount >= 0) {
         continue;
       }
-      const days = typeof data.days === 'number' ? data.days : parseFloat(data.days);
-      const need = Math.ceil((matBurn.daysLeft - days) * matBurn.dailyAmount);
+      const consumed = days * -matBurn.dailyAmount;
+      const need = Math.max(0, Math.ceil(consumed - matBurn.inventory + 1));
       if (need > 0) {
         parsedGroup[ticker] = need;
       }

--- a/src/features/XIT/BURN/BURNACT.ts
+++ b/src/features/XIT/BURN/BURNACT.ts
@@ -1,0 +1,21 @@
+import '@src/features/XIT/ACT/actions/cx-buy/cx-buy';
+import '@src/features/XIT/ACT/actions/mtra/mtra';
+import '@src/features/XIT/ACT/material-groups/resupply/resupply';
+
+import BurnActWindow from '@src/features/XIT/BURN/BurnActWindow.vue';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses';
+
+xit.add({
+  command: 'BURNACT',
+  name: parameters => {
+    if (parameters[0]) {
+      const site = sitesStore.getByPlanetNaturalIdOrName(parameters[0]);
+      const name = site ? getEntityNameFromAddress(site.address) : parameters[0];
+      return `BURN RESUPPLY - ${name}`;
+    }
+    return 'BURN RESUPPLY';
+  },
+  description: 'Executes a resupply action package for a planet from the burn screen.',
+  component: () => BurnActWindow,
+});

--- a/src/features/XIT/BURN/BurnActWindow.vue
+++ b/src/features/XIT/BURN/BurnActWindow.vue
@@ -4,7 +4,6 @@ import ExecuteActionPackage from '@src/features/XIT/ACT/ExecuteActionPackage.vue
 import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
 import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses';
 import { configurableValue } from '@src/features/XIT/ACT/shared-types';
-import { userData } from '@src/store/user-data';
 
 // Join all parameters in case a naturalId was split on underscores by the XIT router.
 const parameters = useXitParameters();

--- a/src/features/XIT/BURN/BurnActWindow.vue
+++ b/src/features/XIT/BURN/BurnActWindow.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { useXitParameters } from '@src/hooks/use-xit-parameters';
+import ExecuteActionPackage from '@src/features/XIT/ACT/ExecuteActionPackage.vue';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses';
+import { configurableValue } from '@src/features/XIT/ACT/shared-types';
+import { userData } from '@src/store/user-data';
+
+// Join all parameters in case a naturalId was split on underscores by the XIT router.
+const parameters = useXitParameters();
+const naturalId = parameters.join(' ');
+
+const site = computed(() => sitesStore.getByPlanetNaturalIdOrName(naturalId));
+const planetName = computed(() =>
+  site.value ? getEntityNameFromAddress(site.value.address) : undefined,
+);
+
+const pkg = computed(
+  () =>
+    ({
+      global: { name: `Burn Resupply: ${planetName.value ?? naturalId}` },
+      groups: [
+        {
+          type: 'Resupply' as UserData.MaterialGroupType,
+          name: 'Resupply',
+          planet: planetName.value,
+          days: configurableValue,
+          useBaseInv: true,
+        },
+      ],
+      actions: [
+        {
+          type: 'CX Buy' as UserData.ActionType,
+          name: 'CX Buy',
+          group: 'Resupply',
+          exchange: configurableValue,
+          useCXInv: true,
+        },
+        {
+          type: 'MTRA' as UserData.ActionType,
+          name: 'MTRA',
+          group: 'Resupply',
+          origin: configurableValue,
+          dest: configurableValue,
+        },
+      ],
+    }) as UserData.ActionPackageData,
+);
+</script>
+
+<template>
+  <div v-if="!planetName">Planet "{{ naturalId }}" not found.</div>
+  <ExecuteActionPackage v-else :pkg="pkg" />
+</template>

--- a/src/features/XIT/BURN/PlanetHeader.vue
+++ b/src/features/XIT/BURN/PlanetHeader.vue
@@ -30,6 +30,9 @@ const days = computed(() => countDays(burn.burn));
         <PrunButton dark inline @click="showBuffer(`INV ${burn.storeId.substring(0, 8)}`)">
           INV
         </PrunButton>
+        <PrunButton dark inline @click="showBuffer(`XIT BURNACT ${burn.naturalId}`)"
+          >ACT</PrunButton
+        >
       </div>
     </td>
   </tr>


### PR DESCRIPTION
I vibe-coded a feature to add an ACT button to the XIT BURN buffer that opens a preconfigured action package to resupply that planet.  It's preconfigured to use the number of days the user has set for resupply in XIT SET, but is user-configurable.  It has a configurable CX Buy action and then a configurable MTRA action.  

Beyond convenience, I think it is most helpful for new players who don't know how to set up an action package and properly set up material groups and cx buy/mtra actions themselves.  

Given I am not an experienced programmer, I put this here more as inspiration if someone with a higher-skill level wants to implement it.  I did run the agents.md reviews and believe in good-faith that the repo comports with those and the game's underlying mod restrictions.  

https://github.com/user-attachments/assets/789b8676-c471-4fbe-93b1-f8900024a705

  Adds an ACT button next to BS/INV in XIT BURN planet rows. Clicking it                                                                                                                      
  opens XIT BURNACT <naturalId> which builds a transient resupply action
  package (Resupply group → CX Buy → MTRA) and shows the execution UI.  
                                                                                                                                                                                              
  - Resupply days and planet are pre-filled from the clicked row and the
    XIT SET burn.resupply setting, both overridable in the configure window                                                                                                                   
  - Adds configure-on-execution support for the resupply days field        
  - Adds configure-on-execution support for the CX Buy exchange field                                                                                                                         
  - New XIT BURNACT command renders ExecuteActionPackage with a transient
    (non-persisted) ActionPackageData — no saved package required 