### PR TITLE
MTRA config: filter destination list based on selected origin

### DIFF
--- a/src/features/XIT/ACT/actions/mtra/Configure.vue
+++ b/src/features/XIT/ACT/actions/mtra/Configure.vue
@@ -37,13 +37,11 @@ if (data.origin === configurableValue && !config.origin && originStorages.value.
 
 const destinationStorages = computed(() => {
   let storages = [...allStorages.value];
-  if (data.origin !== configurableValue) {
-    const origin = deserializeStorage(data.origin);
-    if (origin) {
-      storages = storages.filter(x => atSameLocation(x, origin) && x !== origin);
-    }
+  const originRef = data.origin !== configurableValue ? data.origin : config.origin;
+  const origin = deserializeStorage(originRef);
+  if (origin) {
+    storages = storages.filter(x => atSameLocation(x, origin) && x !== origin);
   }
-
   return storages.sort(storageSort);
 });
 


### PR DESCRIPTION
A QOL improvement that has been working well for me.  Filters the destination field in MTRA XIT ACT buffers to possible destinations when both origin and destination are set to "Configure on Execution".  Selecting an origin now filters the destination dropdown to same-location storages only.  Avoids extremely long lists of destinations to scroll through. 

https://github.com/user-attachments/assets/959eafe8-c291-47e4-a8d2-8b84dbdf0330