### PR TITLE
Add PROD button to XIT BURN for native PROD buffer

### DIFF
--- a/src/core/burn.ts
+++ b/src/core/burn.ts
@@ -23,6 +23,7 @@ export interface BurnValues {
 }
 
 export interface PlanetBurn {
+  prodSiteId: string;
   storeId: string;
   planetName: string;
   naturalId: string;
@@ -48,6 +49,7 @@ const burnBySiteId = computed(() => {
         }
 
         return {
+          prodSiteId: id,
           storeId: storage?.[0]?.id,
           planetName: getEntityNameFromAddress(site.address),
           naturalId: getEntityNaturalIdFromAddress(site.address),

--- a/src/features/XIT/BURN/BURN.vue
+++ b/src/features/XIT/BURN/BURN.vue
@@ -124,7 +124,13 @@ const planetBurn = computed(() => {
     }
   }
 
-  const overallSection = { burn: overallBurn, planetName: 'Overall', naturalId: '', storeId: '' };
+  const overallSection = {
+    burn: overallBurn,
+    planetName: 'Overall',
+    naturalId: '',
+    prodSiteId: '',
+    storeId: '',
+  };
   if (queryResult.value.overallOnly) {
     return [overallSection];
   }

--- a/src/features/XIT/BURN/PlanetHeader.vue
+++ b/src/features/XIT/BURN/PlanetHeader.vue
@@ -30,6 +30,9 @@ const days = computed(() => countDays(burn.burn));
         <PrunButton dark inline @click="showBuffer(`INV ${burn.storeId.substring(0, 8)}`)">
           INV
         </PrunButton>
+        <PrunButton dark inline @click="showBuffer(`PROD ${burn.prodSiteId.substring(0, 8)}`)">
+          PROD
+        </PrunButton>
       </div>
     </td>
   </tr>

--- a/src/features/XIT/BURN/PlanetHeader.vue
+++ b/src/features/XIT/BURN/PlanetHeader.vue
@@ -4,6 +4,7 @@ import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
 import PrunButton from '@src/components/PrunButton.vue';
 import { PlanetBurn } from '@src/core/burn';
 import { countDays } from '@src/features/XIT/BURN/utils';
+import { useXitParameters } from '@src/hooks/use-xit-parameters';
 
 const { burn } = defineProps<{
   burn: PlanetBurn;
@@ -11,6 +12,9 @@ const { burn } = defineProps<{
   minimized?: boolean;
   onClick: () => void;
 }>();
+
+const parameters = useXitParameters();
+const showProdButton = computed(() => parameters.length === 0);
 
 const days = computed(() => countDays(burn.burn));
 </script>
@@ -30,7 +34,11 @@ const days = computed(() => countDays(burn.burn));
         <PrunButton dark inline @click="showBuffer(`INV ${burn.storeId.substring(0, 8)}`)">
           INV
         </PrunButton>
-        <PrunButton dark inline @click="showBuffer(`PROD ${burn.prodSiteId.substring(0, 8)}`)">
+        <PrunButton
+          v-if="showProdButton"
+          dark
+          inline
+          @click="showBuffer(`PROD ${burn.prodSiteId.substring(0, 8)}`)">
           PROD
         </PrunButton>
       </div>


### PR DESCRIPTION
Adds a button to the XIT BURN command that opens the relevant base's native PROD menu, similar to BS or INV. I'm aware of the XIT PROD menu, but I personally prefer having the native PROD menu for when I want to view current production status, as the UI just works a bit better for me when quickly looking it over. 

<img width="495" height="509" alt="image" src="https://github.com/user-attachments/assets/5fd4a9eb-488c-46f1-a50a-96d318a52e00" />

Adding this button to XIT BURN is more of a QOL than anything else, as I am currently using XIT BURN as a central hub for all my bases on one screen. 

If needed, I can expand the change to the XIT PROD buffer as well, but I figured that was a bit redundant. 

There is also a PROD button on the overall; it should be hooked up properly to the native PROD menu. 