### PR TITLE
PLI: Show COGC program type in Chamber of Global Commerce row

### DIFF
--- a/src/features/basic/pli-cogc-label.ts
+++ b/src/features/basic/pli-cogc-label.ts
@@ -1,0 +1,33 @@
+import { planetsStore } from '@src/infrastructure/prun-api/data/planets';
+
+function formatCogcLabel(programType?: string | null) {
+  if (!programType) {
+    return 'COGC (Inactive)';
+  }
+  const cleaned = programType
+    .replace(/^(ADVERTISING|WORKFORCE)_/, '')
+    .replace(/^\w/, c => c.toUpperCase())
+    .replace(/\w+$/, c => c.toLowerCase());
+  return `COGC (${cleaned})`;
+}
+
+function onTileReady(tile: PrunTile) {
+  subscribe($$(tile.anchor, C.PlanetaryProjectsList.row), row => {
+    const link = _$(row, C.Link.link);
+    if (!link || link.textContent !== 'Chamber of Global Commerce') {
+      return;
+    }
+    const programType = planetsStore.find(tile.parameter)?.cogcProgramType;
+    link.textContent = formatCogcLabel(programType);
+  });
+}
+
+function init() {
+  tiles.observe('PLI', onTileReady);
+}
+
+features.add(
+  import.meta.url,
+  init,
+  'PLI: Replaces "Chamber of Global Commerce" row label with "COGC ({program type})".',
+);

--- a/src/infrastructure/prun-api/data/planets.ts
+++ b/src/infrastructure/prun-api/data/planets.ts
@@ -5,6 +5,7 @@ import { createMapGetter } from '@src/infrastructure/prun-api/data/create-map-ge
 interface Planet {
   naturalId: string;
   name: string;
+  cogcProgramType?: string | null;
 }
 
 const store = createEntityStore<Planet>({
@@ -17,6 +18,18 @@ onApiMessage({
   FIO_PLANET_DATA(data: { planets: Planet[] }) {
     store.setAll(data.planets);
     store.setFetched();
+  },
+  DATA_DATA(data: {
+    body: { naturalId: string; cogcProgramType?: string | null };
+    path: string[];
+  }) {
+    if (data.path[0] !== 'planets' || data.path.length !== 2) {
+      return;
+    }
+    const existing = state.getById(data.body.naturalId);
+    if (existing) {
+      store.updateOne({ ...existing, cogcProgramType: data.body.cogcProgramType });
+    }
   },
 });
 


### PR DESCRIPTION
PLI: Show COGC program type in Chamber of Global Commerce row
  
  The "Chamber of Global Commerce" label in PLI is a long name that tells you nothing about what the CoGC is actually doing. This replaces it with a compact, informative label based on the active program.

  Examples:
  - ADVERTISING_ELECTRONICS → COGC (Electronics)
  - WORKFORCE_PIONEERS → COGC (Pioneers)
  - No active program → COGC (Inactive)

  Implementation

  planets.ts — extends planetsStore to handle DATA_DATA WebSocket messages. When a PLI tile is opened, the game sends planet data including cogcProgramType; this patches it onto the existing planet entity in the store.

  pli-cogc-label.ts — new feature that watches PLI tile rows for the CoGC link and rewrites its text using the label formatter above. Strips the ADVERTISING_/WORKFORCE_ prefix, title-cases the remainder.