### PR TITLE
feat(SHPI): add base inv and warehouse context bar buttons

### DIFF
--- a/src/features/basic/shpi-base-inv-button.tsx
+++ b/src/features/basic/shpi-base-inv-button.tsx
@@ -46,6 +46,9 @@ async function onTileReady(tile: PrunTile) {
     return (
       <div
         class={[C.ContextControls.item, C.fonts.fontRegular, C.type.typeSmall]}
+        onMousedown={(e: MouseEvent) => {
+          if (e.shiftKey) e.preventDefault();
+        }}
         onClick={(e: MouseEvent) => {
           const cmd = `INV ${store.id.substring(0, 8)}`;
           if (e.shiftKey) {

--- a/src/features/basic/shpi-base-inv-button.tsx
+++ b/src/features/basic/shpi-base-inv-button.tsx
@@ -47,7 +47,9 @@ async function onTileReady(tile: PrunTile) {
       <div
         class={[C.ContextControls.item, C.fonts.fontRegular, C.type.typeSmall]}
         onMousedown={(e: MouseEvent) => {
-          if (e.shiftKey) e.preventDefault();
+          if (e.shiftKey) {
+            e.preventDefault();
+          }
         }}
         onClick={(e: MouseEvent) => {
           const cmd = `INV ${store.id.substring(0, 8)}`;

--- a/src/features/basic/shpi-base-inv-button.tsx
+++ b/src/features/basic/shpi-base-inv-button.tsx
@@ -1,0 +1,119 @@
+import { shipsStore } from '@src/infrastructure/prun-api/data/ships';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
+import { setBufferSize, showBuffer } from '@src/infrastructure/prun-ui/buffers';
+import {
+  getLocationLineFromAddress,
+  isPlanetLine,
+} from '@src/infrastructure/prun-api/data/addresses';
+import { clickElement, changeInputValue } from '@src/util';
+import { getPrunId } from '@src/infrastructure/prun-ui/attributes';
+import { UI_TILES_CHANGE_COMMAND } from '@src/infrastructure/prun-api/client-messages';
+import { dispatchClientPrunMessage } from '@src/infrastructure/prun-api/prun-api-listener';
+
+async function onTileReady(tile: PrunTile) {
+  const ship = computed(() => shipsStore.getByRegistration(tile.parameter));
+
+  const planetNaturalId = computed(() => {
+    const s = ship.value;
+    if (!s || s.flightId !== null) {
+      return undefined;
+    }
+    const location = getLocationLineFromAddress(s.address ?? undefined);
+    if (!isPlanetLine(location)) {
+      return undefined;
+    }
+    return location.entity.naturalId;
+  });
+
+  const baseStore = computed(() => {
+    const id = planetNaturalId.value;
+    if (!id) {
+      return undefined;
+    }
+    const site = sitesStore.getByPlanetNaturalId(id);
+    return storagesStore.all.value?.find(x => x.addressableId === site?.siteId);
+  });
+
+  const contextBar = await $(tile.frame, C.ContextControls.container);
+
+  createFragmentApp(() => {
+    const store = baseStore.value;
+    const id = planetNaturalId.value;
+    if (!store || !id) {
+      return null;
+    }
+    return (
+      <div
+        class={[C.ContextControls.item, C.fonts.fontRegular, C.type.typeSmall]}
+        onClick={(e: MouseEvent) => {
+          const cmd = `INV ${store.id.substring(0, 8)}`;
+          if (e.shiftKey) {
+            void openCompanionBuffer(tile, cmd);
+          } else {
+            showBuffer(cmd);
+          }
+        }}>
+        <span>
+          <span class={C.ContextControls.cmd}>INV {id}</span>
+        </span>
+      </div>
+    );
+  }).prependTo(contextBar);
+}
+
+async function openCompanionBuffer(tile: PrunTile, command: string) {
+  const windowEl = tile.frame.closest(`.${C.Window.window}`) as HTMLElement | null;
+
+  if (tile.container.classList.contains(C.Window.body)) {
+    const parsedW = parseInt(tile.container.style.width, 10);
+    const parsedH = parseInt(tile.container.style.height, 10);
+    const w = Number.isNaN(parsedW) ? 600 : parsedW;
+    const h = Number.isNaN(parsedH) ? 400 : parsedH;
+    setBufferSize(tile.id, w + 450, h);
+
+    const splitButton = _$$(tile.frame, C.TileControls.control).find(x => x.textContent === '|');
+    await clickElement(splitButton);
+
+    if (!windowEl) {
+      return;
+    }
+
+    const node = await $(windowEl, C.Node.node);
+    const companion = _$$(node, C.Node.child)[1] as HTMLElement | undefined;
+    if (companion) {
+      await setChildCommand(companion, command);
+    }
+  } else if (tile.container.classList.contains(C.Node.child)) {
+    const node = tile.container.parentElement!;
+    const sibling = _$$(node, C.Node.child).find(x => x !== tile.container);
+    if (sibling) {
+      await setChildCommand(sibling, command);
+    }
+  }
+}
+
+async function setChildCommand(child: Element, command: string) {
+  const tileEl = _$(child, C.Tile.tile) as HTMLElement | null;
+  if (!tileEl) {
+    return;
+  }
+
+  const id = getPrunId(tileEl)!;
+  const message = UI_TILES_CHANGE_COMMAND(id, command);
+  if (!dispatchClientPrunMessage(message)) {
+    const input = (await $(child, C.PanelSelector.input)) as HTMLInputElement;
+    changeInputValue(input, command);
+    input.form!.requestSubmit();
+  }
+}
+
+function init() {
+  tiles.observe('SHPI', onTileReady);
+}
+
+features.add(
+  import.meta.url,
+  init,
+  'SHPI: Adds a Base Inv button when the ship is landed at a planet with a player base.',
+);

--- a/src/features/basic/shpi-warehouse-button.tsx
+++ b/src/features/basic/shpi-warehouse-button.tsx
@@ -1,0 +1,119 @@
+import { shipsStore } from '@src/infrastructure/prun-api/data/ships';
+import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
+import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
+import { setBufferSize, showBuffer } from '@src/infrastructure/prun-ui/buffers';
+import {
+  getLocationLineFromAddress,
+  isPlanetLine,
+} from '@src/infrastructure/prun-api/data/addresses';
+import { clickElement, changeInputValue } from '@src/util';
+import { getPrunId } from '@src/infrastructure/prun-ui/attributes';
+import { UI_TILES_CHANGE_COMMAND } from '@src/infrastructure/prun-api/client-messages';
+import { dispatchClientPrunMessage } from '@src/infrastructure/prun-api/prun-api-listener';
+
+async function onTileReady(tile: PrunTile) {
+  const ship = computed(() => shipsStore.getByRegistration(tile.parameter));
+
+  const planetNaturalId = computed(() => {
+    const s = ship.value;
+    if (!s || s.flightId !== null) {
+      return undefined;
+    }
+    const location = getLocationLineFromAddress(s.address ?? undefined);
+    if (!isPlanetLine(location)) {
+      return undefined;
+    }
+    return location.entity.naturalId;
+  });
+
+  const warehouseStore = computed(() => {
+    const id = planetNaturalId.value;
+    if (!id) {
+      return undefined;
+    }
+    const warehouse = warehousesStore.getByEntityNaturalId(id);
+    return storagesStore.getById(warehouse?.storeId);
+  });
+
+  const contextBar = await $(tile.frame, C.ContextControls.container);
+
+  createFragmentApp(() => {
+    const ws = warehouseStore.value;
+    const id = planetNaturalId.value;
+    if (!ws || !id) {
+      return null;
+    }
+    return (
+      <div
+        class={[C.ContextControls.item, C.fonts.fontRegular, C.type.typeSmall]}
+        onClick={(e: MouseEvent) => {
+          const cmd = `INV ${ws.id.substring(0, 8)}`;
+          if (e.shiftKey) {
+            void openCompanionBuffer(tile, cmd);
+          } else {
+            showBuffer(cmd);
+          }
+        }}>
+        <span>
+          <span class={C.ContextControls.cmd}>WAR {id}</span>
+        </span>
+      </div>
+    );
+  }).prependTo(contextBar);
+}
+
+async function openCompanionBuffer(tile: PrunTile, command: string) {
+  const windowEl = tile.frame.closest(`.${C.Window.window}`) as HTMLElement | null;
+
+  if (tile.container.classList.contains(C.Window.body)) {
+    const parsedW = parseInt(tile.container.style.width, 10);
+    const parsedH = parseInt(tile.container.style.height, 10);
+    const w = Number.isNaN(parsedW) ? 600 : parsedW;
+    const h = Number.isNaN(parsedH) ? 400 : parsedH;
+    setBufferSize(tile.id, w + 450, h);
+
+    const splitButton = _$$(tile.frame, C.TileControls.control).find(x => x.textContent === '|');
+    await clickElement(splitButton);
+
+    if (!windowEl) {
+      return;
+    }
+
+    const node = await $(windowEl, C.Node.node);
+    const companion = _$$(node, C.Node.child)[1] as HTMLElement | undefined;
+    if (companion) {
+      await setChildCommand(companion, command);
+    }
+  } else if (tile.container.classList.contains(C.Node.child)) {
+    const node = tile.container.parentElement!;
+    const sibling = _$$(node, C.Node.child).find(x => x !== tile.container);
+    if (sibling) {
+      await setChildCommand(sibling, command);
+    }
+  }
+}
+
+async function setChildCommand(child: Element, command: string) {
+  const tileEl = _$(child, C.Tile.tile) as HTMLElement | null;
+  if (!tileEl) {
+    return;
+  }
+
+  const id = getPrunId(tileEl)!;
+  const message = UI_TILES_CHANGE_COMMAND(id, command);
+  if (!dispatchClientPrunMessage(message)) {
+    const input = (await $(child, C.PanelSelector.input)) as HTMLInputElement;
+    changeInputValue(input, command);
+    input.form!.requestSubmit();
+  }
+}
+
+function init() {
+  tiles.observe('SHPI', onTileReady);
+}
+
+features.add(
+  import.meta.url,
+  init,
+  'SHPI: Adds a Warehouse button when the ship is landed at a planet with a player warehouse.',
+);

--- a/src/features/basic/shpi-warehouse-button.tsx
+++ b/src/features/basic/shpi-warehouse-button.tsx
@@ -47,7 +47,9 @@ async function onTileReady(tile: PrunTile) {
       <div
         class={[C.ContextControls.item, C.fonts.fontRegular, C.type.typeSmall]}
         onMousedown={(e: MouseEvent) => {
-          if (e.shiftKey) e.preventDefault();
+          if (e.shiftKey) {
+            e.preventDefault();
+          }
         }}
         onClick={(e: MouseEvent) => {
           const cmd = `INV ${ws.id.substring(0, 8)}`;

--- a/src/features/basic/shpi-warehouse-button.tsx
+++ b/src/features/basic/shpi-warehouse-button.tsx
@@ -46,6 +46,9 @@ async function onTileReady(tile: PrunTile) {
     return (
       <div
         class={[C.ContextControls.item, C.fonts.fontRegular, C.type.typeSmall]}
+        onMousedown={(e: MouseEvent) => {
+          if (e.shiftKey) e.preventDefault();
+        }}
         onClick={(e: MouseEvent) => {
           const cmd = `INV ${ws.id.substring(0, 8)}`;
           if (e.shiftKey) {


### PR DESCRIPTION
Adds two context bar buttons to the SHPI buffer:

  - INV {planetId} — appears when the ship is landed at a planet where the player has a base; opens the base inventory
  - WAR {planetId} — appears when the ship is landed at a planet where the player has a warehouse; opens the warehouse inventory

  Both buttons are hidden while the ship is in flight or at a station.

  Shift-click behaviour

  Shift-clicking either button opens the target inventory as a horizontal companion buffer instead of a new floating buffer:
  - Floating tile: tile is widened by 450 px and split horizontally; the inventory command is set in the new right-hand tile
  - Already in a split: the sibling tile is reused and its command is replaced
  - Docked tile: no split occurs (same limitation as other companion-buffer features)
  - mousedown default is suppressed on shift to prevent browser text selection
   
https://github.com/user-attachments/assets/0ddee12b-c366-4fef-845f-25dd87eb2a55