### PR TITLE
Fix showBuffer by improving lifecycle management for websocket

### DIFF
--- a/src/infrastructure/prun-api/socket-io-middleware.ts
+++ b/src/infrastructure/prun-api/socket-io-middleware.ts
@@ -46,7 +46,9 @@ export default function socketIOMiddleware<T>(middleware: Middleware<T>) {
           }
           if (prop === 'onclose') {
             target.onclose = e => {
-              middleware.dispatchClientMessage.value = undefined;
+              if (middleware.dispatchClientMessage.value === dispatchClientMessage) {
+                middleware.dispatchClientMessage.value = undefined;
+              }
               value?.(e);
             };
             return true;

--- a/src/infrastructure/prun-api/socket-io-middleware.ts
+++ b/src/infrastructure/prun-api/socket-io-middleware.ts
@@ -13,10 +13,10 @@ export default function socketIOMiddleware<T>(middleware: Middleware<T>) {
   window.WebSocket = new Proxy(WebSocket, {
     construct(target: typeof WebSocket, args: [string, (string | string[])?]) {
       const ws = new target(...args);
+      let dispatchClientMessage: ((message: T) => void) | undefined = undefined;
 
       return new Proxy(ws, {
         set(target, prop, value) {
-          let dispatchClientMessage: ((message: T) => void) | undefined = undefined;
           if (prop === 'onmessage') {
             dispatchClientMessage = message => {
               value(new MessageEvent('message', { data: encodeMessage(message) }));

--- a/src/infrastructure/prun-api/socket-io-middleware.ts
+++ b/src/infrastructure/prun-api/socket-io-middleware.ts
@@ -13,10 +13,14 @@ export default function socketIOMiddleware<T>(middleware: Middleware<T>) {
   window.WebSocket = new Proxy(WebSocket, {
     construct(target: typeof WebSocket, args: [string, (string | string[])?]) {
       const ws = new target(...args);
+      let dispatchClientMessage: ((payload: T) => void) | undefined = undefined;
 
       return new Proxy(ws, {
         set(target, prop, value) {
           if (prop === 'onmessage') {
+            dispatchClientMessage = message => {
+              value(new MessageEvent('message', { data: encodeMessage(message) }));
+            };
             target.onmessage = async e => {
               const data = await processMessage(e.data, middleware);
               if (data !== e.data) {
@@ -35,9 +39,7 @@ export default function socketIOMiddleware<T>(middleware: Middleware<T>) {
           }
           if (prop === 'onopen') {
             target.onopen = e => {
-              middleware.dispatchClientMessage.value = message => {
-                target.onmessage!(new MessageEvent('message', { data: encodeMessage(message) }));
-              };
+              middleware.dispatchClientMessage.value = dispatchClientMessage;
               value?.(e);
             };
             return true;

--- a/src/infrastructure/prun-api/socket-io-middleware.ts
+++ b/src/infrastructure/prun-api/socket-io-middleware.ts
@@ -36,7 +36,7 @@ export default function socketIOMiddleware<T>(middleware: Middleware<T>) {
           if (prop === 'onopen') {
             target.onopen = e => {
               middleware.dispatchClientMessage.value = message => {
-                target.onmessage?.(new MessageEvent('message', { data: encodeMessage(message) }));
+                target.onmessage!(new MessageEvent('message', { data: encodeMessage(message) }));
               };
               value?.(e);
             };

--- a/src/infrastructure/prun-api/socket-io-middleware.ts
+++ b/src/infrastructure/prun-api/socket-io-middleware.ts
@@ -16,14 +16,10 @@ export default function socketIOMiddleware<T>(middleware: Middleware<T>) {
 
       return new Proxy(ws, {
         set(target, prop, value) {
+          let dispatchClientMessage: ((message: T) => void) | undefined = undefined;
           if (prop === 'onmessage') {
-            console.log('opening ws', ws.url);
-            target.onopen = () => {
-              console.log('opened ws, assigning dispatch', ws.url);
-              middleware.dispatchClientMessage.value = message => {
-                console.log('dispatching client message', ws.url, message, value);
-                value(new MessageEvent('message', { data: encodeMessage(message) }));
-              };
+            dispatchClientMessage = message => {
+              value(new MessageEvent('message', { data: encodeMessage(message) }));
             };
             target.onmessage = async e => {
               const data = await processMessage(e.data, middleware);
@@ -41,8 +37,14 @@ export default function socketIOMiddleware<T>(middleware: Middleware<T>) {
             };
             return true;
           }
+          if (prop === 'onopen') {
+            target.onopen = e => {
+              middleware.dispatchClientMessage.value = dispatchClientMessage;
+              value?.(e);
+            };
+            return true;
+          }
           if (prop === 'onclose') {
-            console.log('closing websocket', ws.url);
             target.onclose = e => {
               middleware.dispatchClientMessage.value = undefined;
               value?.(e);

--- a/src/infrastructure/prun-api/socket-io-middleware.ts
+++ b/src/infrastructure/prun-api/socket-io-middleware.ts
@@ -13,14 +13,10 @@ export default function socketIOMiddleware<T>(middleware: Middleware<T>) {
   window.WebSocket = new Proxy(WebSocket, {
     construct(target: typeof WebSocket, args: [string, (string | string[])?]) {
       const ws = new target(...args);
-      let dispatchClientMessage: ((message: T) => void) | undefined = undefined;
 
       return new Proxy(ws, {
         set(target, prop, value) {
           if (prop === 'onmessage') {
-            dispatchClientMessage = message => {
-              value(new MessageEvent('message', { data: encodeMessage(message) }));
-            };
             target.onmessage = async e => {
               const data = await processMessage(e.data, middleware);
               if (data !== e.data) {
@@ -39,7 +35,9 @@ export default function socketIOMiddleware<T>(middleware: Middleware<T>) {
           }
           if (prop === 'onopen') {
             target.onopen = e => {
-              middleware.dispatchClientMessage.value = dispatchClientMessage;
+              middleware.dispatchClientMessage.value = message => {
+                target.onmessage?.(new MessageEvent('message', { data: encodeMessage(message) }));
+              };
               value?.(e);
             };
             return true;

--- a/src/infrastructure/prun-api/socket-io-middleware.ts
+++ b/src/infrastructure/prun-api/socket-io-middleware.ts
@@ -17,8 +17,13 @@ export default function socketIOMiddleware<T>(middleware: Middleware<T>) {
       return new Proxy(ws, {
         set(target, prop, value) {
           if (prop === 'onmessage') {
-            middleware.dispatchClientMessage.value = message => {
-              value(new MessageEvent('message', { data: encodeMessage(message) }));
+            console.log('opening ws', ws.url);
+            target.onopen = () => {
+              console.log('opened ws, assigning dispatch', ws.url);
+              middleware.dispatchClientMessage.value = message => {
+                console.log('dispatching client message', ws.url, message, value);
+                value(new MessageEvent('message', { data: encodeMessage(message) }));
+              };
             };
             target.onmessage = async e => {
               const data = await processMessage(e.data, middleware);
@@ -33,6 +38,14 @@ export default function socketIOMiddleware<T>(middleware: Middleware<T>) {
                 });
               }
               value(e);
+            };
+            return true;
+          }
+          if (prop === 'onclose') {
+            console.log('closing websocket', ws.url);
+            target.onclose = e => {
+              middleware.dispatchClientMessage.value = undefined;
+              value?.(e);
             };
             return true;
           }

--- a/src/infrastructure/prun-ui/buffers.ts
+++ b/src/infrastructure/prun-ui/buffers.ts
@@ -42,8 +42,9 @@ export async function showBuffer(command: string, options?: ShowBufferOptions) {
     }
   }
   await acquireSlot();
+  console.log('showBuffer', command, 'creating!');
   const create = await $(document.documentElement, C.Dock.create);
-
+  console.log('showBuffer', command, 'created!');
   try {
     const windows = document.getElementsByClassName(C.Window.window);
     const seenWindows = new Set(Array.from(windows));
@@ -59,8 +60,13 @@ export async function showBuffer(command: string, options?: ShowBufferOptions) {
       });
       create.click();
     });
+    console.log('showBuffer', command, 'got new windows!');
     await processWindow(newWindow, command, options);
+    console.log('showBuffer', command, 'processed window!');
     return newWindow;
+  } catch (e) {
+    console.error(e);
+    throw e;
   } finally {
     releaseSlot();
   }
@@ -84,12 +90,15 @@ function releaseSlot() {
 }
 
 async function processWindow(window: HTMLDivElement, command: string, options?: ShowBufferOptions) {
+  console.log('showBuffer', 'processWindow', command, 'Processing!');
   const input = _$(window, C.PanelSelector.input) as HTMLInputElement;
   const form = input.form;
   if (!form?.isConnected) {
+    console.log('showBuffer', 'processWindow', command, 'form not connected!');
     return;
   }
   if (!(options?.autoSubmit ?? true)) {
+    console.log('showBuffer', 'processWindow', command, 'not autosubmitting!');
     changeInputValue(input, command);
     return;
   }
@@ -97,6 +106,7 @@ async function processWindow(window: HTMLDivElement, command: string, options?: 
   const tile = _$(window, C.Tile.tile);
   const id = getPrunId(tile!);
   if (options?.autoClose) {
+    console.log('showBuffer', 'processWindow', command, 'hiding dockTab!');
     const dockLabel = id?.padStart(2, '0');
     const dockTab = _$$(document, C.Dock.buffer).find(
       x => _$(x, C.Dock.title)?.textContent === dockLabel,
@@ -107,15 +117,19 @@ async function processWindow(window: HTMLDivElement, command: string, options?: 
   }
   const message = UI_TILES_CHANGE_COMMAND(id!, command);
   if (!dispatchClientPrunMessage(message)) {
+    console.log('showBuffer', 'processWindow', command, "couldn't message?");
     changeInputValue(input, command);
     await sleep(0);
     form.requestSubmit();
   }
+  console.log('showBuffer', 'processWindow', command, 'Finding selector!');
   const selector = await $(window, C.Tile.selector);
+  console.log('showBuffer', 'processWindow', command, 'Selector found!', selector);
   await Promise.any([
     new Promise<void>(resolve => onNodeDisconnected(input, resolve)),
     $(selector, C.Tile.warning),
   ]);
+  console.log('showBuffer', 'processWindow', command, 'closed!');
   if (!options?.autoClose) {
     window.classList.remove(css.hidden);
     return;

--- a/src/infrastructure/prun-ui/buffers.ts
+++ b/src/infrastructure/prun-ui/buffers.ts
@@ -106,11 +106,12 @@ async function processWindow(window: HTMLDivElement, command: string, options?: 
     }
   }
   const message = UI_TILES_CHANGE_COMMAND(id!, command);
-  if (!dispatchClientPrunMessage(message)) {
+  const selector = await $(window, C.Tile.selector);
+  const fallbackTileChange = async () => {
     changeInputValue(input, command);
     await sleep(0);
     form.requestSubmit();
-  }
+  };
   const selector = await $(window, C.Tile.selector);
   await Promise.any([
     new Promise<void>(resolve => onNodeDisconnected(input, resolve)),

--- a/src/infrastructure/prun-ui/buffers.ts
+++ b/src/infrastructure/prun-ui/buffers.ts
@@ -42,9 +42,8 @@ export async function showBuffer(command: string, options?: ShowBufferOptions) {
     }
   }
   await acquireSlot();
-  console.log('showBuffer', command, 'creating!');
   const create = await $(document.documentElement, C.Dock.create);
-  console.log('showBuffer', command, 'created!');
+
   try {
     const windows = document.getElementsByClassName(C.Window.window);
     const seenWindows = new Set(Array.from(windows));
@@ -60,13 +59,8 @@ export async function showBuffer(command: string, options?: ShowBufferOptions) {
       });
       create.click();
     });
-    console.log('showBuffer', command, 'got new windows!');
     await processWindow(newWindow, command, options);
-    console.log('showBuffer', command, 'processed window!');
     return newWindow;
-  } catch (e) {
-    console.error(e);
-    throw e;
   } finally {
     releaseSlot();
   }
@@ -90,15 +84,12 @@ function releaseSlot() {
 }
 
 async function processWindow(window: HTMLDivElement, command: string, options?: ShowBufferOptions) {
-  console.log('showBuffer', 'processWindow', command, 'Processing!');
   const input = _$(window, C.PanelSelector.input) as HTMLInputElement;
   const form = input.form;
   if (!form?.isConnected) {
-    console.log('showBuffer', 'processWindow', command, 'form not connected!');
     return;
   }
   if (!(options?.autoSubmit ?? true)) {
-    console.log('showBuffer', 'processWindow', command, 'not autosubmitting!');
     changeInputValue(input, command);
     return;
   }
@@ -106,7 +97,6 @@ async function processWindow(window: HTMLDivElement, command: string, options?: 
   const tile = _$(window, C.Tile.tile);
   const id = getPrunId(tile!);
   if (options?.autoClose) {
-    console.log('showBuffer', 'processWindow', command, 'hiding dockTab!');
     const dockLabel = id?.padStart(2, '0');
     const dockTab = _$$(document, C.Dock.buffer).find(
       x => _$(x, C.Dock.title)?.textContent === dockLabel,
@@ -117,19 +107,15 @@ async function processWindow(window: HTMLDivElement, command: string, options?: 
   }
   const message = UI_TILES_CHANGE_COMMAND(id!, command);
   if (!dispatchClientPrunMessage(message)) {
-    console.log('showBuffer', 'processWindow', command, "couldn't message?");
     changeInputValue(input, command);
     await sleep(0);
     form.requestSubmit();
   }
-  console.log('showBuffer', 'processWindow', command, 'Finding selector!');
   const selector = await $(window, C.Tile.selector);
-  console.log('showBuffer', 'processWindow', command, 'Selector found!', selector);
   await Promise.any([
     new Promise<void>(resolve => onNodeDisconnected(input, resolve)),
     $(selector, C.Tile.warning),
   ]);
-  console.log('showBuffer', 'processWindow', command, 'closed!');
   if (!options?.autoClose) {
     window.classList.remove(css.hidden);
     return;

--- a/src/infrastructure/prun-ui/buffers.ts
+++ b/src/infrastructure/prun-ui/buffers.ts
@@ -112,11 +112,21 @@ async function processWindow(window: HTMLDivElement, command: string, options?: 
     await sleep(0);
     form.requestSubmit();
   };
-  const selector = await $(window, C.Tile.selector);
+  if (!dispatchClientPrunMessage(message)) {
+    fallbackTileChange();
+  }
+  let tileChanged = false;
+  setTimeout(() => {
+    if (tileChanged) {
+      return;
+    }
+    fallbackTileChange();
+  }, 100);
   await Promise.any([
     new Promise<void>(resolve => onNodeDisconnected(input, resolve)),
     $(selector, C.Tile.warning),
   ]);
+  tileChanged = true;
   if (!options?.autoClose) {
     window.classList.remove(css.hidden);
     return;


### PR DESCRIPTION
When opening a buffer, showBuffer checks if it can dispatchClientMessage to the currently active websocket by checking if the method is defined. Currently, dispatchClientMessage is defined as soon as a websocket is instantiated--before it has opened and messages can actually be dispatched. Because showBuffer does not allow concurrent invocations, this can lead to a situation where rPrUn waits indefinitely for a buffer that was requested during a period when a new websocket has been instantiated but not opened and can therefore not process the UI_TILE_CHANGE message.

This issue can occur when the active websocket is disconnected, a new one is created, and showBuffer is called in the period of time between the closing of the old websocket and the opening of the new one. During this period, dispatchClientMessage is defined but ineffectual.

This PR fixes this issue by setting dispatchClientMessage only when the active websocket is opened and back to undefined when the active websocket is closed, correctly allowing for showBuffer to use its fallback. 

One potential side effect of this fix is that dispatchClientMessage now calls the proxied onmessage event rather than the original one, but I have not observed nor do I foresee any issues created by this. 

Additionally, there is a chance that a new websocket is opened before the previous one has closed, leading to a situation where the closing of the old websocket clears the dispatchClientMessage of the new one. I am not familiar enough with websocket lifecycle management or the source code of PrUn to determine whether this is worth writing a check for.