### PR TITLE
Add location-based filter support to XIT CONTS

### DIFF
--- a/src/features/XIT/CONTS/CONTS.vue
+++ b/src/features/XIT/CONTS/CONTS.vue
@@ -4,9 +4,76 @@ import { contractsStore } from '@src/infrastructure/prun-api/data/contracts';
 import ContractRow from '@src/features/XIT/CONTS/ContractRow.vue';
 import { isEmpty } from 'ts-extras';
 import { canAcceptContract } from '@src/features/XIT/CONTS/utils';
+import { useXitParameters } from '@src/hooks/use-xit-parameters';
+import { getEntityNaturalIdFromAddress } from '@src/infrastructure/prun-api/data/addresses';
+import { convertToPlanetNaturalId } from '@src/core/planet-natural-id';
+import { findWithQuery } from '@src/utils/find-with-query';
+
+const parameters = useXitParameters();
+
+const queryResult = computed(() => {
+  if (parameters.length === 0 || !contractsStore.all.value) {
+    return contractsStore.all.value;
+  }
+  const contractsByNaturalId = new Map<string, Set<PrunApi.Contract>>();
+  for (const contract of contractsStore.all.value ?? []) {
+    for (const condition of contract.conditions) {
+      const naturalId = getEntityNaturalIdFromAddress(condition.address);
+      if (naturalId) {
+        contractsByNaturalId.set(
+          naturalId,
+          (contractsByNaturalId.get(naturalId) ?? new Set()).add(contract),
+        );
+      }
+      const destinationNaturalId = getEntityNaturalIdFromAddress(condition.destination);
+      if (destinationNaturalId) {
+        contractsByNaturalId.set(
+          destinationNaturalId,
+          (contractsByNaturalId.get(destinationNaturalId) ?? new Set()).add(contract),
+        );
+      }
+    }
+  }
+  const result = findWithQuery(parameters, (term, parts) =>
+    findContracts(term, parts, contractsStore.all.value, contractsByNaturalId),
+  );
+  let matches = result.include;
+  // In my opinion, the only time that a query with no results should return everything is when the only term is a 'NOT' term.
+  // This only tests if the first term is a 'NOT' term, but I cannot think of a reason to combine regular terms and 'NOT' terms anyway.
+  // This way, the query can return no results when a given location has no contracts.
+  if (result.includeAll && parameters[0]?.toLowerCase() == 'not') {
+    matches = contractsStore.all.value;
+  }
+  if (result.excludeAll) {
+    matches = [];
+  }
+  matches = matches.filter(x => !result.exclude.has(x));
+  return matches;
+});
+
+function findContracts(
+  term: string,
+  parts: string[],
+  contracts: PrunApi.Contract[] | undefined,
+  contractsByNaturalId: Map<string, Set<PrunApi.Contract>>,
+) {
+  if (term === 'all') {
+    return contracts;
+  }
+
+  const naturalId = convertToPlanetNaturalId(term, parts);
+  if (!naturalId) {
+    return;
+  }
+  const result = contractsByNaturalId.get(naturalId);
+  if (result) {
+    return Array.from(result.values());
+  }
+  return result;
+}
 
 const filtered = computed(() =>
-  contractsStore.all.value!.filter(shouldShowContract).sort(compareContracts),
+  queryResult.value!.filter(shouldShowContract).sort(compareContracts),
 );
 
 function shouldShowContract(contract: PrunApi.Contract) {

--- a/src/utils/find-with-query.ts
+++ b/src/utils/find-with-query.ts
@@ -42,7 +42,7 @@ export function findWithQuery<T>(
 
     if (nextTerm === 'not') {
       isNot = true;
-      excludeAll = true;
+      excludeAll = false;
       nextTerm = '';
       nextTermParts.length = 0;
       continue;


### PR DESCRIPTION
I have a planet where I have no base but a warehouse and I send buy contracts to fill the warehouse whenever it's empty. Sometimes I forget if I've sent the new contract, so I thought it would be nice to have a tile where I could see all active contracts for a given location. So, I decided to copy the logic of XIT BURN and used parameters to query all contracts for the relevant ones.
<img width="3267" height="1939" alt="image" src="https://github.com/user-attachments/assets/2d4a8812-0361-4fc1-b174-622f4fba4201" />

<img width="409" height="981" alt="image" src="https://github.com/user-attachments/assets/0db6e3f4-3f4f-43c3-9d64-96844d62d9e1" />

I made one change to how XIT BURN works by way of changing find-with-query.ts to set excludeAll to false as soon as a NOT term is detected. This does not seem to have had an appreciable change to the behavior of XIT BURN, but it allows XIT CONTS NOT <location> to display all contracts when that location has no contracts. The behavior of this feature seemed odd and not quite in line with the discussion in [this discord thread](https://discord.com/channels/667551433503014924/1444828250852560969) which seems to indicate a purpose for locations that include other locations (like FK-794 including FK-794b) but XIT BURN does not have this functionality and findWithQuery is not implemented on any features that do. All that said, I understand that I may not understand, so I would easily surrender this side effect for this feature.