### PR TITLE
XIT BURN: Fix TSV export reporting double inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - `PROD`: Fixed order completion time not displaying for `PROD {planet id}` (`prod-order-eta`)
+- `XIT BURN`: Fixed the TSV export reporting double the inventory in the "Inv" column
 
 ## 26.6.22.2033
 

--- a/src/features/XIT/BURN/BURN.vue
+++ b/src/features/XIT/BURN/BURN.vue
@@ -207,7 +207,7 @@ function formatBurnTable(burns: PlanetBurn[]) {
       const mat = planet.burn[material.ticker];
       const days = mat.dailyAmount >= 0 ? '' : Math.floor(mat.daysLeft).toString();
       const burn = round(mat.dailyAmount);
-      const inv = mat.inventory + mat.inventory;
+      const inv = mat.inventory + mat.remainingAllocation;
       const need =
         mat.dailyAmount >= 0 || mat.daysLeft > resupply
           ? 0


### PR DESCRIPTION
The TSV export computed inv as mat.inventory + mat.inventory, doubling the reported inventory. Use mat.inventory + mat.remainingAllocation to match the displayed inventory and the daysLeft calculation.


Proposed changelog entry
### Fixed

- `XIT BURN`: Fixed the TSV export reporting double the inventory in the "Inv" column