### PR TITLE
feat: Add XIT STOCK command

### DIFF
--- a/docs/feature-patterns.md
+++ b/docs/feature-patterns.md
@@ -84,6 +84,18 @@ The file is auto-imported via `import.meta.glob` in `src/features/index.ts` — 
 
 The command should be short. Refer to `docs/game/commands.csv` for an example of game commands. Alias is usually added for backwards compatibility or if the community REALLY wants it.
 
+### Parameters
+
+The panel receives `parameters: string[]`, produced by splitting the raw parameter on `/[_ ]+/` (both underscores and spaces are separators — see `xit-commands.ts`). So `XIT CMD_EDIT_My_Preset` yields `['EDIT', 'My', 'Preset']`. Rejoin multi-word names with `.join(' ')`.
+
+### Multi-preset screens (ACT, STOCK)
+
+Screens that manage several named, user-defined presets share one convention:
+
+- Persist presets as an array in `userData` (e.g. `userData.actionPackages`, `userData.stockPresets`).
+- Route by parameter: `XIT CMD_<name>` views/executes a preset, `XIT CMD_EDIT_<name>` edits it, no params shows the list. The root component `unshift`s the command onto `parameters` so it can index `parameters[1]` uniformly, then delegates to List / Display / Edit components (see `ACT.vue`, `STOCK.vue`).
+- Preset names are validated with `isValidPackageName` (`src/features/XIT/ACT/utils.ts`) — spaces allowed, underscores are not (they are the param separator, mapped to/from spaces via `.split('_').join(' ')`).
+
 ---
 
 ## Auto-Imports (no explicit import needed)

--- a/src/core/stock.ts
+++ b/src/core/stock.ts
@@ -1,0 +1,120 @@
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
+import { warehousesStore } from '@src/infrastructure/prun-api/data/warehouses';
+import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
+import {
+  getEntityNameFromAddress,
+  getEntityNaturalIdFromAddress,
+} from '@src/infrastructure/prun-api/data/addresses';
+import { getPlanetBurn } from '@src/core/burn';
+
+export type StockTrend = 'filling' | 'draining' | 'static';
+
+export interface StockItemStatus {
+  ticker: string;
+  material?: PrunApi.Material;
+  max: number;
+  warehouse: boolean;
+  current: number;
+  // Net daily production/consumption from XIT BURN (base inventory only).
+  rate: number;
+  // Current divided by max. Can exceed 1 when overstocked.
+  percent: number;
+  // Days to reach the target (both directions), or NaN when not trending.
+  days: number;
+  trend: StockTrend;
+  // True when the item is draining and already at or below its target (running low).
+  danger: boolean;
+}
+
+export interface StockPlanetStatus {
+  // The raw identifier the user configured for this planet.
+  planet: string;
+  planetName: string;
+  naturalId: string;
+  storeId?: string;
+  // Whether the configured planet resolved to an owned site.
+  found: boolean;
+  items: StockItemStatus[];
+}
+
+function sumTicker(stores: PrunApi.Store[] | undefined, ticker: string) {
+  if (!stores) {
+    return 0;
+  }
+  let total = 0;
+  for (const store of stores) {
+    for (const item of store.items) {
+      const quantity = item.quantity;
+      if (quantity && quantity.material.ticker === ticker) {
+        total += quantity.amount;
+      }
+    }
+  }
+  return total;
+}
+
+function computeDays(current: number, max: number, rate: number) {
+  if (rate > 0) {
+    // Filling. Days until we reach the target; already at/above target has no ETA.
+    if (current < max) {
+      return { days: (max - current) / rate, trend: 'filling' as const, danger: false };
+    }
+    return { days: Number.POSITIVE_INFINITY, trend: 'filling' as const, danger: false };
+  }
+  if (rate < 0) {
+    // Draining. Above target: days to fall back to it. At/below target: days until empty.
+    if (current > max) {
+      return { days: (current - max) / -rate, trend: 'draining' as const, danger: false };
+    }
+    return { days: current / -rate, trend: 'draining' as const, danger: true };
+  }
+  return { days: NaN, trend: 'static' as const, danger: false };
+}
+
+export function getPlanetStock(config: UserData.StockPlanetData): StockPlanetStatus {
+  const site = sitesStore.find(config.planet);
+  const naturalId =
+    (site ? getEntityNaturalIdFromAddress(site.address) : undefined) ?? config.planet;
+  const planetName = (site ? getEntityNameFromAddress(site.address) : undefined) ?? config.planet;
+  const baseStores = site ? storagesStore.getByAddressableId(site.siteId) : undefined;
+  const warehouse = warehousesStore.getByEntityNaturalId(naturalId);
+  const warehouseStore = storagesStore.getById(warehouse?.storeId);
+  const burn = site ? getPlanetBurn(site)?.burn : undefined;
+
+  const items = config.items.map<StockItemStatus>(item => {
+    const ticker = item.ticker.toUpperCase();
+    const material = materialsStore.getByTicker(ticker);
+    const includeWarehouse = item.warehouse === true;
+    const base = sumTicker(baseStores, ticker);
+    const wh = includeWarehouse
+      ? sumTicker(warehouseStore ? [warehouseStore] : undefined, ticker)
+      : 0;
+    const current = base + wh;
+    const max = item.max;
+    const rate = burn?.[ticker]?.dailyAmount ?? 0;
+    const percent = max > 0 ? current / max : current > 0 ? Number.POSITIVE_INFINITY : 0;
+    const { days, trend, danger } = computeDays(current, max, rate);
+    return {
+      ticker,
+      material,
+      max,
+      warehouse: includeWarehouse,
+      current,
+      rate,
+      percent,
+      days,
+      trend,
+      danger,
+    };
+  });
+
+  return {
+    planet: config.planet,
+    planetName,
+    naturalId,
+    storeId: baseStores?.[0]?.id,
+    found: site !== undefined,
+    items,
+  };
+}

--- a/src/features/XIT/STOCK/CreateStockPreset.vue
+++ b/src/features/XIT/STOCK/CreateStockPreset.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import PrunButton from '@src/components/PrunButton.vue';
+import SectionHeader from '@src/components/SectionHeader.vue';
+import Active from '@src/components/forms/Active.vue';
+import TextInput from '@src/components/forms/TextInput.vue';
+import Commands from '@src/components/forms/Commands.vue';
+import { isValidPackageName } from '@src/features/XIT/ACT/utils';
+
+const { onCreate } = defineProps<{ onCreate: (name: string) => void }>();
+
+const emit = defineEmits<{ (e: 'close'): void }>();
+
+const name = ref('');
+const nameError = ref(false);
+watch(name, () => (nameError.value = !isValidPackageName(name.value)));
+
+function onCreateClick() {
+  if (name.value.length === 0 || !isValidPackageName(name.value)) {
+    nameError.value = true;
+    return;
+  }
+  onCreate(name.value);
+  emit('close');
+}
+</script>
+
+<template>
+  <div :class="C.DraftConditionEditor.form">
+    <SectionHeader>Create Stock Preset</SectionHeader>
+    <form>
+      <Active label="Name" :error="nameError">
+        <TextInput v-model="name" />
+      </Active>
+      <Commands>
+        <PrunButton primary @click="onCreateClick">CREATE</PrunButton>
+      </Commands>
+    </form>
+  </div>
+</template>

--- a/src/features/XIT/STOCK/EditStockPreset.vue
+++ b/src/features/XIT/STOCK/EditStockPreset.vue
@@ -1,0 +1,127 @@
+<script setup lang="ts">
+import Header from '@src/components/Header.vue';
+import SectionHeader from '@src/components/SectionHeader.vue';
+import Commands from '@src/components/forms/Commands.vue';
+import Active from '@src/components/forms/Active.vue';
+import TextInput from '@src/components/forms/TextInput.vue';
+import NumberInput from '@src/components/forms/NumberInput.vue';
+import RadioItem from '@src/components/forms/RadioItem.vue';
+import PrunButton from '@src/components/PrunButton.vue';
+import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
+import { showTileOverlay } from '@src/infrastructure/prun-ui/tile-overlay';
+import RenameStockPreset from '@src/features/XIT/STOCK/RenameStockPreset.vue';
+import removeArrayElement from '@src/utils/remove-array-element';
+import { objectId } from '@src/utils/object-id';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { getEntityNameFromAddress } from '@src/infrastructure/prun-api/data/addresses';
+import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
+
+const { preset } = defineProps<{ preset: UserData.StockPresetData }>();
+
+function paramName(name: string) {
+  return name.split(' ').join('_');
+}
+
+function resolvedPlanetName(planet: UserData.StockPlanetData) {
+  const site = sitesStore.find(planet.planet);
+  return site ? getEntityNameFromAddress(site.address) : undefined;
+}
+
+function planetTitle(planet: UserData.StockPlanetData) {
+  return resolvedPlanetName(planet) ?? (planet.planet || 'New planet');
+}
+
+function isPlanetInvalid(planet: UserData.StockPlanetData) {
+  return planet.planet.length > 0 && resolvedPlanetName(planet) === undefined;
+}
+
+function isTickerInvalid(item: UserData.StockItemData) {
+  return (
+    item.ticker.length > 0 && materialsStore.getByTicker(item.ticker.toUpperCase()) === undefined
+  );
+}
+
+function onAddPlanetClick() {
+  preset.planets.push({ planet: '', items: [] });
+}
+
+function onRemovePlanetClick(planet: UserData.StockPlanetData) {
+  removeArrayElement(preset.planets, planet);
+}
+
+function onAddItemClick(planet: UserData.StockPlanetData) {
+  planet.items.push({ ticker: '', max: 0 });
+}
+
+function onRemoveItemClick(planet: UserData.StockPlanetData, item: UserData.StockItemData) {
+  removeArrayElement(planet.items, item);
+}
+
+function onRenameClick(ev: Event) {
+  showTileOverlay(ev, RenameStockPreset, {
+    name: preset.name,
+    onRename: name => {
+      preset.name = name;
+      showBuffer(`XIT STOCK_EDIT_${paramName(name)}`);
+    },
+  });
+}
+
+function onOpenClick() {
+  showBuffer(`XIT STOCK_${paramName(preset.name)}`);
+}
+</script>
+
+<template>
+  <Header :class="$style.header">{{ preset.name }}</Header>
+  <template v-for="planet in preset.planets" :key="objectId(planet)">
+    <SectionHeader>{{ planetTitle(planet) }}</SectionHeader>
+    <form>
+      <Active label="Planet" :error="isPlanetInvalid(planet)">
+        <TextInput v-model="planet.planet" />
+      </Active>
+      <template v-for="(item, i) in planet.items" :key="objectId(item)">
+        <Active :label="`Ticker #${i + 1}`" :error="isTickerInvalid(item)">
+          <TextInput v-model="item.ticker" />
+        </Active>
+        <Active :label="`Max #${i + 1}`">
+          <NumberInput v-model="item.max" />
+        </Active>
+        <Active :label="`Warehouse #${i + 1}`">
+          <RadioItem v-model="item.warehouse" horizontal>Include warehouse</RadioItem>
+        </Active>
+        <Commands :label="`Item #${i + 1}`">
+          <PrunButton dark @click="onRemoveItemClick(planet, item)">REMOVE ITEM</PrunButton>
+        </Commands>
+      </template>
+      <Commands>
+        <PrunButton primary @click="onAddItemClick(planet)">ADD ITEM</PrunButton>
+        <PrunButton dark @click="onRemovePlanetClick(planet)">REMOVE PLANET</PrunButton>
+      </Commands>
+    </form>
+  </template>
+  <form :class="$style.sectionCommands">
+    <Commands label="Planet">
+      <PrunButton primary @click="onAddPlanetClick">ADD PLANET</PrunButton>
+    </Commands>
+  </form>
+  <SectionHeader>Commands</SectionHeader>
+  <form>
+    <Commands label="Rename">
+      <PrunButton primary @click="onRenameClick">RENAME</PrunButton>
+    </Commands>
+    <Commands label="Open">
+      <PrunButton primary @click="onOpenClick">OPEN</PrunButton>
+    </Commands>
+  </form>
+</template>
+
+<style module>
+.header {
+  margin-left: 4px;
+}
+
+.sectionCommands {
+  margin-top: 0.75rem;
+}
+</style>

--- a/src/features/XIT/STOCK/RenameStockPreset.vue
+++ b/src/features/XIT/STOCK/RenameStockPreset.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import PrunButton from '@src/components/PrunButton.vue';
+import SectionHeader from '@src/components/SectionHeader.vue';
+import Active from '@src/components/forms/Active.vue';
+import TextInput from '@src/components/forms/TextInput.vue';
+import Commands from '@src/components/forms/Commands.vue';
+import { isValidPackageName } from '@src/features/XIT/ACT/utils';
+
+const { name: initialName, onRename } = defineProps<{
+  name: string;
+  onRename: (name: string) => void;
+}>();
+
+const emit = defineEmits<{ (e: 'close'): void }>();
+
+const name = ref(initialName);
+const nameError = ref(false);
+watch(name, () => (nameError.value = !isValidPackageName(name.value)));
+
+function onRenameClick() {
+  if (name.value.length === 0 || !isValidPackageName(name.value)) {
+    nameError.value = true;
+    return;
+  }
+  onRename(name.value);
+  emit('close');
+}
+</script>
+
+<template>
+  <div :class="C.DraftConditionEditor.form">
+    <SectionHeader>Rename Stock Preset</SectionHeader>
+    <form>
+      <Active label="Name" :error="nameError">
+        <TextInput v-model="name" />
+      </Active>
+      <Commands>
+        <PrunButton primary @click="onRenameClick">RENAME</PrunButton>
+      </Commands>
+    </form>
+  </div>
+</template>

--- a/src/features/XIT/STOCK/STOCK.ts
+++ b/src/features/XIT/STOCK/STOCK.ts
@@ -1,0 +1,18 @@
+import STOCK from '@src/features/XIT/STOCK/STOCK.vue';
+
+xit.add({
+  command: 'STOCK',
+  name: parameters => {
+    if (parameters.length === 0) {
+      return 'STOCK PRESETS';
+    }
+    if (parameters[0].toUpperCase() === 'EDIT') {
+      return 'EDIT STOCK PRESET';
+    }
+    return `STOCK - ${parameters.join(' ').split('_').join(' ')}`;
+  },
+  description: 'Tracks configured materials against per-planet target amounts.',
+  optionalParameters: 'EDIT and/or Preset Name',
+  contextItems: parameters => (parameters.length > 0 ? [{ cmd: 'XIT STOCK' }] : []),
+  component: () => STOCK,
+});

--- a/src/features/XIT/STOCK/STOCK.vue
+++ b/src/features/XIT/STOCK/STOCK.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { useXitParameters } from '@src/hooks/use-xit-parameters';
+import { userData } from '@src/store/user-data';
+import StockPresetList from '@src/features/XIT/STOCK/StockPresetList.vue';
+import EditStockPreset from '@src/features/XIT/STOCK/EditStockPreset.vue';
+import StockDisplay from '@src/features/XIT/STOCK/StockDisplay.vue';
+
+const parameters = useXitParameters();
+parameters.unshift('STOCK');
+
+let presetName = undefined as string | undefined;
+const edit = parameters[1]?.toLowerCase() === 'edit';
+if (edit) {
+  presetName = parameters.slice(2).join(' ');
+}
+const show = parameters[1] !== undefined && !edit;
+if (show) {
+  presetName = parameters.slice(1).join(' ');
+}
+
+const preset = computed(() => userData.stockPresets.find(x => x.name === presetName));
+</script>
+
+<template>
+  <StockPresetList v-if="parameters.length === 1" />
+  <div v-else-if="!preset">Stock preset "{{ presetName }}" not found.</div>
+  <EditStockPreset v-else-if="edit" :preset="preset" />
+  <StockDisplay v-else :preset="preset" />
+</template>

--- a/src/features/XIT/STOCK/StockDaysCell.vue
+++ b/src/features/XIT/STOCK/StockDaysCell.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { userData } from '@src/store/user-data';
+import { fixed0, fixed01 } from '@src/utils/format';
+
+const { days, danger } = defineProps<{ days: number; danger?: boolean }>();
+
+const formattedDays = computed(() => {
+  if (isNaN(days)) {
+    return '—';
+  }
+  if (!isFinite(days) || days > 999) {
+    return '∞';
+  }
+  if (days >= 10) {
+    return fixed0(Math.floor(days));
+  }
+  return fixed01(days);
+});
+
+// Only color the cell when the item is running low (draining at/below target).
+const burnClass = computed(() => {
+  if (!danger || isNaN(days)) {
+    return {};
+  }
+  const flooredDays = Math.floor(days);
+  return {
+    [C.Workforces.daysMissing]: flooredDays <= userData.settings.burn.red,
+    [C.Workforces.daysWarning]: flooredDays <= userData.settings.burn.yellow,
+    [C.Workforces.daysSupplied]: flooredDays > userData.settings.burn.yellow,
+  };
+});
+</script>
+
+<template>
+  <td :style="{ position: 'relative' }">
+    <div
+      :style="{ position: 'absolute', left: 0, top: 0, width: '100%', height: '100%' }"
+      :class="burnClass" />
+    <span>{{ formattedDays }}</span>
+  </td>
+</template>

--- a/src/features/XIT/STOCK/StockDisplay.vue
+++ b/src/features/XIT/STOCK/StockDisplay.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import LoadingSpinner from '@src/components/LoadingSpinner.vue';
+import PrunButton from '@src/components/PrunButton.vue';
+import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
+import { sitesStore } from '@src/infrastructure/prun-api/data/sites';
+import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
+import { getPlanetStock } from '@src/core/stock';
+import StockSection from '@src/features/XIT/STOCK/StockSection.vue';
+import { useTileState } from '@src/features/XIT/STOCK/tile-state';
+
+const { preset } = defineProps<{ preset: UserData.StockPresetData }>();
+
+const ready = computed(() => sitesStore.fetched.value && storagesStore.fetched.value);
+const sections = computed(() => {
+  if (!ready.value) {
+    return undefined;
+  }
+  return preset.planets.map(getPlanetStock);
+});
+
+const canMinimize = computed(() => (sections.value?.length ?? 0) > 1);
+
+const expand = useTileState('expand');
+const anyExpanded = computed(() => expand.value.length > 0);
+
+function onExpandAllClick() {
+  if (expand.value.length > 0) {
+    expand.value = [];
+  } else {
+    expand.value = sections.value?.map(s => s.naturalId || s.planet) ?? [];
+  }
+}
+
+function paramName(name: string) {
+  return name.split(' ').join('_');
+}
+</script>
+
+<template>
+  <LoadingSpinner v-if="sections === undefined" />
+  <div v-else-if="preset.planets.length === 0" :class="$style.empty">
+    <div>This preset has no planets yet.</div>
+    <PrunButton primary @click="showBuffer(`XIT STOCK_EDIT_${paramName(preset.name)}`)">
+      CONFIGURE
+    </PrunButton>
+  </div>
+  <table v-else>
+    <thead>
+      <tr>
+        <th v-if="canMinimize" :class="$style.expand" @click="onExpandAllClick">
+          {{ anyExpanded ? '-' : '+' }}
+        </th>
+        <th v-else />
+        <th>Stock</th>
+        <th>%</th>
+        <th>Days</th>
+      </tr>
+    </thead>
+    <StockSection
+      v-for="section in sections"
+      :key="section.naturalId || section.planet"
+      :section="section"
+      :can-minimize="canMinimize" />
+  </table>
+</template>
+
+<style module>
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.5rem;
+}
+
+.expand {
+  text-align: center;
+  cursor: pointer;
+  user-select: none;
+  font-size: 12px;
+  padding-left: 18px;
+  font-weight: bold;
+}
+</style>

--- a/src/features/XIT/STOCK/StockPresetList.vue
+++ b/src/features/XIT/STOCK/StockPresetList.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+import ActionBar from '@src/components/ActionBar.vue';
+import PrunButton from '@src/components/PrunButton.vue';
+import PrunLink from '@src/components/PrunLink.vue';
+import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
+import { showConfirmationOverlay, showTileOverlay } from '@src/infrastructure/prun-ui/tile-overlay';
+import CreateStockPreset from '@src/features/XIT/STOCK/CreateStockPreset.vue';
+import { userData } from '@src/store/user-data';
+import removeArrayElement from '@src/utils/remove-array-element';
+import { objectId } from '@src/utils/object-id';
+import { vDraggable } from 'vue-draggable-plus';
+import { grip } from '@src/components/grip';
+import GripCell from '@src/components/grip/GripCell.vue';
+import GripHeaderCell from '@src/components/grip/GripHeaderCell.vue';
+
+const stockPresets = computed(() => userData.stockPresets);
+
+function onCreateClick(ev: Event) {
+  showTileOverlay(ev, CreateStockPreset, {
+    onCreate: name => {
+      userData.stockPresets.push({ name, planets: [] });
+      showBuffer('XIT STOCK_EDIT_' + paramName(name));
+    },
+  });
+}
+
+function onDeleteClick(ev: Event, preset: UserData.StockPresetData) {
+  showConfirmationOverlay(ev, () => removeArrayElement(userData.stockPresets, preset), {
+    message: `Are you sure you want to delete the stock preset "${preset.name}"?`,
+    confirmLabel: 'DELETE',
+  });
+}
+
+function paramName(name: string) {
+  return name.split(' ').join('_');
+}
+</script>
+
+<template>
+  <ActionBar>
+    <PrunButton primary @click="onCreateClick">CREATE NEW</PrunButton>
+  </ActionBar>
+  <table>
+    <thead>
+      <tr>
+        <GripHeaderCell />
+        <th>Name</th>
+        <th>Open</th>
+        <th>Edit</th>
+        <th>Delete</th>
+      </tr>
+    </thead>
+    <tbody v-if="stockPresets.length === 0">
+      <tr>
+        <td colspan="5">No stock presets.</td>
+      </tr>
+    </tbody>
+    <tbody v-else v-draggable="[stockPresets, grip.draggable]">
+      <tr v-for="preset in stockPresets" :key="objectId(preset)">
+        <GripCell />
+        <td>
+          <PrunLink inline :command="`XIT STOCK_${paramName(preset.name)}`">
+            {{ preset.name }}
+          </PrunLink>
+        </td>
+        <td>
+          <PrunButton primary @click="showBuffer(`XIT STOCK_${paramName(preset.name)}`)">
+            OPEN
+          </PrunButton>
+        </td>
+        <td>
+          <PrunButton primary @click="showBuffer(`XIT STOCK_EDIT_${paramName(preset.name)}`)">
+            EDIT
+          </PrunButton>
+        </td>
+        <td>
+          <PrunButton dark inline @click="onDeleteClick($event, preset)">delete</PrunButton>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>

--- a/src/features/XIT/STOCK/StockRow.vue
+++ b/src/features/XIT/STOCK/StockRow.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { StockItemStatus } from '@src/core/stock';
+import MaterialIcon from '@src/components/MaterialIcon.vue';
+import StockDaysCell from '@src/features/XIT/STOCK/StockDaysCell.vue';
+import { fixed0, fixed01, percent0, percent1 } from '@src/utils/format';
+
+const { item } = defineProps<{ item: StockItemStatus }>();
+
+const currentText = computed(() =>
+  item.current >= 100 ? fixed0(item.current) : fixed01(item.current),
+);
+const maxText = computed(() => fixed0(item.max));
+
+const percentText = computed(() => {
+  if (!isFinite(item.percent)) {
+    return '∞';
+  }
+  return item.percent >= 1 ? percent0(item.percent) : percent1(item.percent);
+});
+
+const percentClass = computed(() => ({
+  [C.ColoredValue.positive]: item.percent >= 1,
+  [C.ColoredValue.negative]: item.danger,
+}));
+</script>
+
+<template>
+  <tr>
+    <td :class="$style.iconColumn">
+      <MaterialIcon v-if="item.ticker" size="inline-table" :ticker="item.ticker" />
+    </td>
+    <td>
+      <span>
+        {{ currentText }}<span :class="$style.slash">/</span>{{ maxText }}
+        <span v-if="item.warehouse" :class="$style.warehouse" title="Includes warehouse">+W</span>
+      </span>
+    </td>
+    <td>
+      <span :class="percentClass">{{ percentText }}</span>
+    </td>
+    <StockDaysCell :days="item.days" :danger="item.danger" />
+  </tr>
+</template>
+
+<style module>
+.iconColumn {
+  width: 32px;
+  padding: 0;
+}
+
+.slash {
+  color: #999;
+  margin: 0 1px;
+}
+
+.warehouse {
+  color: #999;
+  font-size: 11px;
+  margin-left: 3px;
+}
+</style>

--- a/src/features/XIT/STOCK/StockSection.vue
+++ b/src/features/XIT/STOCK/StockSection.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import { StockPlanetStatus } from '@src/core/stock';
+import StockRow from '@src/features/XIT/STOCK/StockRow.vue';
+import PrunButton from '@src/components/PrunButton.vue';
+import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
+import { useTileState } from '@src/features/XIT/STOCK/tile-state';
+
+const { section, canMinimize } = defineProps<{
+  section: StockPlanetStatus;
+  canMinimize?: boolean;
+}>();
+
+const expand = useTileState('expand');
+const key = computed(() => section.naturalId || section.planet);
+const isMinimized = computed(() => canMinimize && !expand.value.includes(key.value));
+
+function onHeaderClick() {
+  if (!canMinimize) {
+    return;
+  }
+  if (isMinimized.value) {
+    expand.value = [...expand.value, key.value];
+  } else {
+    expand.value = expand.value.filter(x => x !== key.value);
+  }
+}
+</script>
+
+<template>
+  <tbody>
+    <tr :class="$style.row">
+      <td colspan="3" :class="$style.cell" @click="onHeaderClick">
+        <span v-if="canMinimize" :class="$style.minimize">{{ isMinimized ? '+' : '-' }}</span>
+        <span>{{ section.planetName }}</span>
+        <span v-if="!section.found" :class="$style.notFound"> (not found)</span>
+      </td>
+      <td>
+        <div :class="$style.buttons">
+          <PrunButton
+            v-if="section.found"
+            dark
+            inline
+            @click="showBuffer(`BS ${section.naturalId}`)">
+            BS
+          </PrunButton>
+          <PrunButton
+            v-if="section.storeId"
+            dark
+            inline
+            @click="showBuffer(`INV ${section.storeId.substring(0, 8)}`)">
+            INV
+          </PrunButton>
+        </div>
+      </td>
+    </tr>
+  </tbody>
+  <tbody v-if="!isMinimized">
+    <tr v-if="section.items.length === 0">
+      <td colspan="4" :class="$style.emptyRow">No items configured.</td>
+    </tr>
+    <StockRow v-for="item in section.items" :key="item.ticker" :item="item" />
+  </tbody>
+</template>
+
+<style module>
+.row {
+  border-bottom: 1px solid #2b485a;
+}
+
+.cell {
+  font-weight: bold;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.minimize {
+  display: inline-block;
+  width: 26px;
+  text-align: center;
+}
+
+.notFound {
+  color: #d9534f;
+  font-weight: normal;
+}
+
+.buttons {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  column-gap: 0.25rem;
+}
+
+.emptyRow {
+  text-align: center;
+  color: #999;
+}
+</style>

--- a/src/features/XIT/STOCK/tile-state.ts
+++ b/src/features/XIT/STOCK/tile-state.ts
@@ -1,0 +1,5 @@
+import { createTileStateHook } from '@src/store/user-data-tiles';
+
+export const useTileState = createTileStateHook({
+  expand: [] as string[],
+});

--- a/src/store/user-data.ts
+++ b/src/store/user-data.ts
@@ -61,6 +61,7 @@ export const initialUserData = deepFreeze({
   fullEquityMode: true,
   notes: [] as UserData.Note[],
   actionPackages: [] as UserData.ActionPackageData[],
+  stockPresets: [] as UserData.StockPresetData[],
   systemMessages: [] as UserData.SystemMessages[],
   todo: [] as UserData.TaskList[],
   tabs: {

--- a/src/store/user-data.types.d.ts
+++ b/src/store/user-data.types.d.ts
@@ -82,6 +82,24 @@ declare namespace UserData {
     dest?: string;
   }
 
+  interface StockPresetData {
+    name: string;
+    planets: StockPlanetData[];
+  }
+
+  interface StockPlanetData {
+    // Planet natural id or name, resolved via sitesStore.find.
+    planet: string;
+    items: StockItemData[];
+  }
+
+  interface StockItemData {
+    ticker: string;
+    max: number;
+    // Include this planet's warehouse in the "current" amount.
+    warehouse?: boolean;
+  }
+
   interface TaskList {
     id: string;
     name: string;


### PR DESCRIPTION
This command allows you to select a set of planets and items, as well as a Warehouse toggle and max amount for each
and displays the current amount of that item vs the total, a percentage, and a "days to reach" display similar to
the one in XIT BURN. You can also have multiple of these Stock selections, similar to XIT ACT.

Made with the help of Claude Code using Claude Opus 4.8 on High.
