### PR TITLE
Add XIT TOTALS command

### DIFF
--- a/src/core/item-totals.ts
+++ b/src/core/item-totals.ts
@@ -1,0 +1,73 @@
+import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
+import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
+import { exchangesStore } from '@src/infrastructure/prun-api/data/exchanges';
+import { getPriceAt } from '@src/infrastructure/fio/cx';
+
+export interface ItemExchangeValue {
+  code: string;
+  name: string;
+  currency: string;
+  // Worth of the whole holding at this exchange. Undefined when there is no price.
+  value?: number;
+}
+
+export interface ItemTotalStatus {
+  ticker: string;
+  material?: PrunApi.Material;
+  // Total amount across every inventory the company owns.
+  amount: number;
+  // Total weight in tonnes and total volume in cubic metres.
+  weight: number;
+  volume: number;
+  values: ItemExchangeValue[];
+}
+
+// Every exchange, ordered by code, so the columns keep a stable order.
+export const exchanges = computed(() =>
+  [...(exchangesStore.all.value ?? [])].sort((a, b) => a.code.localeCompare(b.code)),
+);
+
+// Sums every material across all owned inventories: bases, warehouses,
+// ship cargo holds and fuel tanks. Construction and upkeep stores are
+// already excluded by storagesStore.
+const totals = computed(() => {
+  const stores = storagesStore.all.value;
+  if (!stores) {
+    return undefined;
+  }
+  const totals = new Map<string, number>();
+  for (const store of stores) {
+    for (const item of store.items) {
+      const quantity = item.quantity;
+      if (!quantity) {
+        continue;
+      }
+      const ticker = quantity.material.ticker;
+      totals.set(ticker, (totals.get(ticker) ?? 0) + quantity.amount);
+    }
+  }
+  return totals;
+});
+
+export function getItemTotal(ticker: string): ItemTotalStatus {
+  const upper = ticker.toUpperCase();
+  const material = materialsStore.getByTicker(upper);
+  const amount = totals.value?.get(upper) ?? 0;
+  const values = exchanges.value.map<ItemExchangeValue>(exchange => {
+    const price = getPriceAt(upper, exchange.code);
+    return {
+      code: exchange.code,
+      name: exchange.name,
+      currency: exchange.currency.code,
+      value: price === undefined ? undefined : price * amount,
+    };
+  });
+  return {
+    ticker: upper,
+    material,
+    amount,
+    weight: (material?.weight ?? 0) * amount,
+    volume: (material?.volume ?? 0) * amount,
+    values,
+  };
+}

--- a/src/features/XIT/TOTALS/CreateTotalsPreset.vue
+++ b/src/features/XIT/TOTALS/CreateTotalsPreset.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import PrunButton from '@src/components/PrunButton.vue';
+import SectionHeader from '@src/components/SectionHeader.vue';
+import Active from '@src/components/forms/Active.vue';
+import TextInput from '@src/components/forms/TextInput.vue';
+import Commands from '@src/components/forms/Commands.vue';
+import { isValidPresetName } from '@src/features/XIT/TOTALS/utils';
+
+const { onCreate } = defineProps<{ onCreate: (name: string) => void }>();
+
+const emit = defineEmits<{ (e: 'close'): void }>();
+
+const name = ref('');
+const nameError = ref(false);
+watch(name, () => (nameError.value = !isValidPresetName(name.value)));
+
+function onCreateClick() {
+  if (name.value.length === 0 || !isValidPresetName(name.value)) {
+    nameError.value = true;
+    return;
+  }
+  onCreate(name.value);
+  emit('close');
+}
+</script>
+
+<template>
+  <div :class="C.DraftConditionEditor.form">
+    <SectionHeader>Create Totals Preset</SectionHeader>
+    <form>
+      <Active label="Name" :error="nameError">
+        <TextInput v-model="name" />
+      </Active>
+      <Commands>
+        <PrunButton primary @click="onCreateClick">CREATE</PrunButton>
+      </Commands>
+    </form>
+  </div>
+</template>

--- a/src/features/XIT/TOTALS/EditTotalsPreset.vue
+++ b/src/features/XIT/TOTALS/EditTotalsPreset.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import Header from '@src/components/Header.vue';
+import SectionHeader from '@src/components/SectionHeader.vue';
+import Commands from '@src/components/forms/Commands.vue';
+import Active from '@src/components/forms/Active.vue';
+import TextInput from '@src/components/forms/TextInput.vue';
+import PrunButton from '@src/components/PrunButton.vue';
+import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
+import { showTileOverlay } from '@src/infrastructure/prun-ui/tile-overlay';
+import RenameTotalsPreset from '@src/features/XIT/TOTALS/RenameTotalsPreset.vue';
+import removeArrayElement from '@src/utils/remove-array-element';
+import { objectId } from '@src/utils/object-id';
+import { materialsStore } from '@src/infrastructure/prun-api/data/materials';
+import { toParamName } from '@src/features/XIT/TOTALS/utils';
+
+const { preset } = defineProps<{ preset: UserData.ItemTotalsPresetData }>();
+
+function isTickerInvalid(item: UserData.ItemTotalsItemData) {
+  return (
+    item.ticker.length > 0 && materialsStore.getByTicker(item.ticker.toUpperCase()) === undefined
+  );
+}
+
+function onAddItemClick() {
+  preset.items.push({ ticker: '' });
+}
+
+function onRemoveItemClick(item: UserData.ItemTotalsItemData) {
+  removeArrayElement(preset.items, item);
+}
+
+function onRenameClick(ev: Event) {
+  showTileOverlay(ev, RenameTotalsPreset, {
+    name: preset.name,
+    onRename: name => {
+      preset.name = name;
+      showBuffer(`XIT TOTALS_EDIT_${toParamName(name)}`);
+    },
+  });
+}
+
+function onOpenClick() {
+  showBuffer(`XIT TOTALS_${toParamName(preset.name)}`);
+}
+</script>
+
+<template>
+  <Header :class="$style.header">{{ preset.name }}</Header>
+  <SectionHeader>Items</SectionHeader>
+  <form>
+    <template v-for="(item, i) in preset.items" :key="objectId(item)">
+      <Active :label="`Ticker #${i + 1}`" :error="isTickerInvalid(item)">
+        <TextInput v-model="item.ticker" />
+      </Active>
+      <Commands :label="`Item #${i + 1}`">
+        <PrunButton dark @click="onRemoveItemClick(item)">REMOVE ITEM</PrunButton>
+      </Commands>
+    </template>
+    <Commands>
+      <PrunButton primary @click="onAddItemClick">ADD ITEM</PrunButton>
+    </Commands>
+  </form>
+  <SectionHeader>Commands</SectionHeader>
+  <form>
+    <Commands label="Rename">
+      <PrunButton primary @click="onRenameClick">RENAME</PrunButton>
+    </Commands>
+    <Commands label="Open">
+      <PrunButton primary @click="onOpenClick">OPEN</PrunButton>
+    </Commands>
+  </form>
+</template>
+
+<style module>
+.header {
+  margin-left: 4px;
+}
+</style>

--- a/src/features/XIT/TOTALS/RenameTotalsPreset.vue
+++ b/src/features/XIT/TOTALS/RenameTotalsPreset.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import PrunButton from '@src/components/PrunButton.vue';
+import SectionHeader from '@src/components/SectionHeader.vue';
+import Active from '@src/components/forms/Active.vue';
+import TextInput from '@src/components/forms/TextInput.vue';
+import Commands from '@src/components/forms/Commands.vue';
+import { isValidPresetName } from '@src/features/XIT/TOTALS/utils';
+
+const { name: initialName, onRename } = defineProps<{
+  name: string;
+  onRename: (name: string) => void;
+}>();
+
+const emit = defineEmits<{ (e: 'close'): void }>();
+
+const name = ref(initialName);
+const nameError = ref(false);
+watch(name, () => (nameError.value = !isValidPresetName(name.value)));
+
+function onRenameClick() {
+  if (name.value.length === 0 || !isValidPresetName(name.value)) {
+    nameError.value = true;
+    return;
+  }
+  onRename(name.value);
+  emit('close');
+}
+</script>
+
+<template>
+  <div :class="C.DraftConditionEditor.form">
+    <SectionHeader>Rename Totals Preset</SectionHeader>
+    <form>
+      <Active label="Name" :error="nameError">
+        <TextInput v-model="name" />
+      </Active>
+      <Commands>
+        <PrunButton primary @click="onRenameClick">RENAME</PrunButton>
+      </Commands>
+    </form>
+  </div>
+</template>

--- a/src/features/XIT/TOTALS/TOTALS.ts
+++ b/src/features/XIT/TOTALS/TOTALS.ts
@@ -1,0 +1,18 @@
+import TOTALS from '@src/features/XIT/TOTALS/TOTALS.vue';
+
+xit.add({
+  command: 'TOTALS',
+  name: parameters => {
+    if (parameters.length === 0) {
+      return 'ITEM TOTALS';
+    }
+    if (parameters[0].toUpperCase() === 'EDIT') {
+      return 'EDIT TOTALS PRESET';
+    }
+    return `TOTALS - ${parameters.join(' ').split('_').join(' ')}`;
+  },
+  description: 'Shows the total amount of each item across all your inventories.',
+  optionalParameters: 'EDIT and/or Preset Name',
+  contextItems: parameters => (parameters.length > 0 ? [{ cmd: 'XIT TOTALS' }] : []),
+  component: () => TOTALS,
+});

--- a/src/features/XIT/TOTALS/TOTALS.vue
+++ b/src/features/XIT/TOTALS/TOTALS.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { useXitParameters } from '@src/hooks/use-xit-parameters';
+import { userData } from '@src/store/user-data';
+import TotalsPresetList from '@src/features/XIT/TOTALS/TotalsPresetList.vue';
+import EditTotalsPreset from '@src/features/XIT/TOTALS/EditTotalsPreset.vue';
+import TotalsDisplay from '@src/features/XIT/TOTALS/TotalsDisplay.vue';
+
+const parameters = useXitParameters();
+parameters.unshift('TOTALS');
+
+let presetName = undefined as string | undefined;
+const edit = parameters[1]?.toLowerCase() === 'edit';
+if (edit) {
+  presetName = parameters.slice(2).join(' ');
+}
+const show = parameters[1] !== undefined && !edit;
+if (show) {
+  presetName = parameters.slice(1).join(' ');
+}
+
+const preset = computed(() => userData.itemTotalsPresets.find(x => x.name === presetName));
+</script>
+
+<template>
+  <TotalsPresetList v-if="parameters.length === 1" />
+  <div v-else-if="!preset">Totals preset "{{ presetName }}" not found.</div>
+  <EditTotalsPreset v-else-if="edit" :preset="preset" />
+  <TotalsDisplay v-else :preset="preset" />
+</template>

--- a/src/features/XIT/TOTALS/TotalsDisplay.vue
+++ b/src/features/XIT/TOTALS/TotalsDisplay.vue
@@ -1,0 +1,139 @@
+<script setup lang="ts">
+import LoadingSpinner from '@src/components/LoadingSpinner.vue';
+import PrunButton from '@src/components/PrunButton.vue';
+import RadioItem from '@src/components/forms/RadioItem.vue';
+import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
+import { storagesStore } from '@src/infrastructure/prun-api/data/storage';
+import { exchanges, getItemTotal } from '@src/core/item-totals';
+import TotalsRow from '@src/features/XIT/TOTALS/TotalsRow.vue';
+import { useTileState } from '@src/features/XIT/TOTALS/tile-state';
+import {
+  formatValue,
+  formatVolume,
+  formatWeight,
+  toParamName,
+} from '@src/features/XIT/TOTALS/utils';
+
+const { preset } = defineProps<{ preset: UserData.ItemTotalsPresetData }>();
+
+const wv = useTileState('wv');
+const total = useTileState('total');
+const cx = useTileState('cx');
+
+const codes = computed(() => cx.value);
+
+const visibleExchanges = computed(() => exchanges.value.filter(x => codes.value.includes(x.code)));
+
+function isShown(code: string) {
+  return codes.value.includes(code);
+}
+
+function toggleExchange(code: string) {
+  cx.value = isShown(code) ? codes.value.filter(x => x !== code) : [...codes.value, code];
+}
+
+const rows = computed(() => {
+  if (!storagesStore.fetched.value) {
+    return undefined;
+  }
+  return preset.items.filter(x => x.ticker.length > 0).map(x => getItemTotal(x.ticker));
+});
+
+// Totals across every item in the preset. A column with a missing price
+// totals to undefined, so a partial sum is never shown as a real number.
+const totals = computed(() => {
+  const list = rows.value;
+  if (!list) {
+    return undefined;
+  }
+  return {
+    weight: sumBy(list, x => x.weight),
+    volume: sumBy(list, x => x.volume),
+    values: visibleExchanges.value.map(exchange =>
+      sumBy(list, x => x.values.find(v => v.code === exchange.code)?.value),
+    ),
+  };
+});
+</script>
+
+<template>
+  <LoadingSpinner v-if="rows === undefined || totals === undefined" />
+  <template v-else>
+    <div :class="C.ComExOrdersPanel.filter">
+      <RadioItem v-model="wv" horizontal>W/V</RadioItem>
+      <div :class="$style.separator" />
+      <RadioItem
+        v-for="exchange in exchanges"
+        :key="exchange.code"
+        horizontal
+        :model-value="isShown(exchange.code)"
+        @update:model-value="toggleExchange(exchange.code)">
+        {{ exchange.code }}
+      </RadioItem>
+      <div :class="$style.separator" />
+      <RadioItem v-model="total" horizontal>TOTAL</RadioItem>
+    </div>
+    <div v-if="rows.length === 0" :class="$style.empty">
+      <div>This preset has no items yet.</div>
+      <PrunButton primary @click="showBuffer(`XIT TOTALS_EDIT_${toParamName(preset.name)}`)">
+        CONFIGURE
+      </PrunButton>
+    </div>
+    <table v-else>
+      <thead>
+        <tr>
+          <th>Item</th>
+          <th>Amt</th>
+          <template v-if="wv">
+            <th :class="$style.numberColumn">Weight</th>
+            <th :class="$style.numberColumn">Volume</th>
+          </template>
+          <th
+            v-for="exchange in visibleExchanges"
+            :key="exchange.code"
+            :class="$style.numberColumn">
+            {{ exchange.code }}
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <TotalsRow v-for="row in rows" :key="row.ticker" :row="row" :codes="codes" :show-wv="wv" />
+        <tr v-if="total" :class="C.IncomeStatementPanel.totals">
+          <td :class="C.IncomeStatementPanel.number">Total</td>
+          <td />
+          <template v-if="wv">
+            <td :class="$style.numberColumn">{{ formatWeight(totals.weight) }}</td>
+            <td :class="$style.numberColumn">{{ formatVolume(totals.volume) }}</td>
+          </template>
+          <td
+            v-for="(exchange, i) in visibleExchanges"
+            :key="exchange.code"
+            :class="$style.numberColumn">
+            {{ formatValue(totals.values[i], exchange.currency.code) }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </template>
+</template>
+
+<style module>
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.5rem;
+}
+
+.separator {
+  width: 1px;
+  align-self: stretch;
+  background-color: #2b485a;
+  margin: 0 0.25rem;
+}
+
+.numberColumn {
+  text-align: right;
+}
+</style>

--- a/src/features/XIT/TOTALS/TotalsPresetList.vue
+++ b/src/features/XIT/TOTALS/TotalsPresetList.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import ActionBar from '@src/components/ActionBar.vue';
+import PrunButton from '@src/components/PrunButton.vue';
+import PrunLink from '@src/components/PrunLink.vue';
+import { showBuffer } from '@src/infrastructure/prun-ui/buffers';
+import { showConfirmationOverlay, showTileOverlay } from '@src/infrastructure/prun-ui/tile-overlay';
+import CreateTotalsPreset from '@src/features/XIT/TOTALS/CreateTotalsPreset.vue';
+import { userData } from '@src/store/user-data';
+import removeArrayElement from '@src/utils/remove-array-element';
+import { objectId } from '@src/utils/object-id';
+import { vDraggable } from 'vue-draggable-plus';
+import { grip } from '@src/components/grip';
+import GripCell from '@src/components/grip/GripCell.vue';
+import GripHeaderCell from '@src/components/grip/GripHeaderCell.vue';
+import { toParamName } from '@src/features/XIT/TOTALS/utils';
+
+const presets = computed(() => userData.itemTotalsPresets);
+
+function onCreateClick(ev: Event) {
+  showTileOverlay(ev, CreateTotalsPreset, {
+    onCreate: name => {
+      userData.itemTotalsPresets.push({ name, items: [] });
+      showBuffer(`XIT TOTALS_EDIT_${toParamName(name)}`);
+    },
+  });
+}
+
+function onDeleteClick(ev: Event, preset: UserData.ItemTotalsPresetData) {
+  showConfirmationOverlay(ev, () => removeArrayElement(userData.itemTotalsPresets, preset), {
+    message: `Are you sure you want to delete the totals preset "${preset.name}"?`,
+    confirmLabel: 'DELETE',
+  });
+}
+</script>
+
+<template>
+  <ActionBar>
+    <PrunButton primary @click="onCreateClick">CREATE NEW</PrunButton>
+  </ActionBar>
+  <table>
+    <thead>
+      <tr>
+        <GripHeaderCell />
+        <th>Name</th>
+        <th>Open</th>
+        <th>Edit</th>
+        <th>Delete</th>
+      </tr>
+    </thead>
+    <tbody v-if="presets.length === 0">
+      <tr>
+        <td colspan="5">No totals presets.</td>
+      </tr>
+    </tbody>
+    <tbody v-else v-draggable="[presets, grip.draggable]">
+      <tr v-for="preset in presets" :key="objectId(preset)">
+        <GripCell />
+        <td>
+          <PrunLink inline :command="`XIT TOTALS_${toParamName(preset.name)}`">
+            {{ preset.name }}
+          </PrunLink>
+        </td>
+        <td>
+          <PrunButton primary @click="showBuffer(`XIT TOTALS_${toParamName(preset.name)}`)">
+            OPEN
+          </PrunButton>
+        </td>
+        <td>
+          <PrunButton primary @click="showBuffer(`XIT TOTALS_EDIT_${toParamName(preset.name)}`)">
+            EDIT
+          </PrunButton>
+        </td>
+        <td>
+          <PrunButton dark inline @click="onDeleteClick($event, preset)">delete</PrunButton>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>

--- a/src/features/XIT/TOTALS/TotalsRow.vue
+++ b/src/features/XIT/TOTALS/TotalsRow.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { ItemTotalStatus } from '@src/core/item-totals';
+import MaterialIcon from '@src/components/MaterialIcon.vue';
+import {
+  formatAmount,
+  formatValue,
+  formatVolume,
+  formatWeight,
+} from '@src/features/XIT/TOTALS/utils';
+
+const { row, codes } = defineProps<{
+  row: ItemTotalStatus;
+  codes: string[];
+  showWv?: boolean;
+}>();
+
+const values = computed(() => row.values.filter(x => codes.includes(x.code)));
+</script>
+
+<template>
+  <tr>
+    <td :class="$style.itemColumn">
+      <MaterialIcon size="inline-table" :ticker="row.ticker" />
+    </td>
+    <td>{{ formatAmount(row.amount) }}</td>
+    <template v-if="showWv">
+      <td :class="$style.numberColumn">{{ formatWeight(row.weight) }}</td>
+      <td :class="$style.numberColumn">{{ formatVolume(row.volume) }}</td>
+    </template>
+    <td v-for="value in values" :key="value.code" :class="$style.numberColumn">
+      {{ formatValue(value.value, value.currency) }}
+    </td>
+  </tr>
+</template>
+
+<style module>
+.itemColumn {
+  width: 32px;
+  padding: 0;
+}
+
+.numberColumn {
+  text-align: right;
+}
+</style>

--- a/src/features/XIT/TOTALS/tile-state.ts
+++ b/src/features/XIT/TOTALS/tile-state.ts
@@ -1,0 +1,8 @@
+import { createTileStateHook } from '@src/store/user-data-tiles';
+
+export const useTileState = createTileStateHook({
+  wv: false,
+  total: false,
+  // Codes of the exchanges whose value column is shown.
+  cx: [] as string[],
+});

--- a/src/features/XIT/TOTALS/utils.ts
+++ b/src/features/XIT/TOTALS/utils.ts
@@ -1,0 +1,27 @@
+import { fixed0, fixed01, fixed2 } from '@src/utils/format';
+
+// Underscores are the XIT parameter separator, so a preset name must not contain one.
+export function isValidPresetName(name: string) {
+  return /^[ 0-9a-zA-Z.-]*$/.test(name);
+}
+
+export function toParamName(name: string) {
+  return name.split(' ').join('_');
+}
+
+export function formatAmount(amount: number) {
+  return amount >= 100 ? fixed0(amount) : fixed01(amount);
+}
+
+// Each exchange trades in its own currency, so the cell carries the code.
+export function formatValue(value: number | undefined, currency: string) {
+  return value === undefined ? '--' : `${fixed0(value)} ${currency}`;
+}
+
+export function formatWeight(weight: number) {
+  return `${fixed2(weight)}t`;
+}
+
+export function formatVolume(volume: number) {
+  return `${fixed2(volume)}m³`;
+}

--- a/src/infrastructure/fio/cx.ts
+++ b/src/infrastructure/fio/cx.ts
@@ -111,7 +111,9 @@ function weightedAverage<T>(
 const ignored = computed(() => new Set(userData.settings.financial.ignoredMaterials.split(',')));
 const mmMaterials = computed(() => new Set(userData.settings.financial.mmMaterials.split(',')));
 
-export function getPrice(ticker?: string | null) {
+// Price of a ticker at one specific exchange, using the configured pricing method.
+// Pass an exchange code (AI1, NC1, ...) or UNIVERSE for the weighted average.
+export function getPriceAt(ticker?: string | null, exchangeCode?: string | null) {
   if (!ticker) {
     return undefined;
   }
@@ -126,7 +128,7 @@ export function getPrice(ticker?: string | null) {
   }
 
   const pricing = userData.settings.pricing;
-  const exchange = cxStore.prices.get(pricing.exchange);
+  const exchange = exchangeCode ? cxStore.prices.get(exchangeCode) : undefined;
   if (!exchange) {
     return undefined;
   }
@@ -163,6 +165,10 @@ export function getPrice(ticker?: string | null) {
   }
 
   return undefined;
+}
+
+export function getPrice(ticker?: string | null) {
+  return getPriceAt(ticker, userData.settings.pricing.exchange);
 }
 
 export function getMaterialPrice(material: PrunApi.Material) {

--- a/src/store/user-data.ts
+++ b/src/store/user-data.ts
@@ -61,6 +61,7 @@ export const initialUserData = deepFreeze({
   fullEquityMode: true,
   notes: [] as UserData.Note[],
   actionPackages: [] as UserData.ActionPackageData[],
+  itemTotalsPresets: [] as UserData.ItemTotalsPresetData[],
   systemMessages: [] as UserData.SystemMessages[],
   todo: [] as UserData.TaskList[],
   tabs: {

--- a/src/store/user-data.types.d.ts
+++ b/src/store/user-data.types.d.ts
@@ -82,6 +82,15 @@ declare namespace UserData {
     dest?: string;
   }
 
+  interface ItemTotalsPresetData {
+    name: string;
+    items: ItemTotalsItemData[];
+  }
+
+  interface ItemTotalsItemData {
+    ticker: string;
+  }
+
   interface TaskList {
     id: string;
     name: string;


### PR DESCRIPTION
Adds `XIT TOTALS`, a panel that shows how much of each material you hold
across your whole company, with optional per-exchange valuation.

`XIT BURN` answers "how long until I run out on this planet". This answers
"how much of this do I own anywhere, and what is it worth". Today that means
adding up base inventories, warehouses and ship holds by hand.

## Usage

- `XIT TOTALS` — the preset list. Create, rename, reorder and delete presets.
- `XIT TOTALS <name>` — show a preset.
- `XIT TOTALS EDIT <name>` — edit the ticker list of a preset.

Presets are stored in `userData.itemTotalsPresets`.

<img width="573" height="210" alt="image" src="https://github.com/user-attachments/assets/352d802f-fd32-41d2-a096-dc2b81376f23" />
<img width="940" height="348" alt="image" src="https://github.com/user-attachments/assets/1b9e934c-31b6-40bf-9550-cace8a16714a" />


## Columns

`Item | Amt | Weight | Volume | <one per enabled exchange>`

- **Amt** sums every store the company owns, as listed above.
  `storagesStore` already excludes construction and upkeep stores.
- **Weight / Volume** are `amount × material.weight` and
  `amount × material.volume`, formatted as `t` and `m³` to match
  `MaterialPurchaseTable`.
- **Exchange columns** show what the whole holding is worth at that exchange,
  in that exchange's own currency, for example `12,400 CIS`. The currency is
  in the cell rather than the header, because the six exchanges use four
  different currencies and the numbers are not comparable across columns.

## Toggles

Toggles live in a `C.ComExOrdersPanel.filter` bar and persist per tile
through `createTileStateHook`, the same as `XIT BURN`.

- **W/V** — adds the Weight and Volume columns.
- **AI1 / CI1 / CI2 / IC1 / NC1 / NC2** — one per exchange, each adds that
  exchange's value column. The list is built from `exchangesStore`, and the
  enabled codes are stored as a string array, so a new exchange would appear
  on its own with no code change.
- **TOTAL** — adds a summary row using the game's own
  `C.IncomeStatementPanel.totals` divider, as `XIT FINBS` does.

The TOTAL row deliberately leaves **Amt** blank. Adding units of different
materials together gives a number with no meaning. Weight, volume and the
currency values do share a unit, so those are summed. A value column totals
to `--` if any item in the preset has no price there, so a partial sum is
never presented as a real number.

## Shared code

`src/infrastructure/fio/cx.ts` gains `getPriceAt(ticker, exchangeCode)`.
The price data was already keyed by exchange; `getPrice` could only read the
one exchange configured in `XIT SET`. `getPrice` now delegates to
`getPriceAt` with that same configured exchange, so existing callers are
unchanged. Valuation honours the user's configured pricing method, ignored
materials and MM materials exactly as before.

## Relationship to #236 (XIT STOCK)

These are complementary, not competing. They answer different questions and
share no code.

**#236 is per-location.** You configure planets, and per planet a list of
tickers with a target amount. It sums that planet's base inventory, plus that
one location's warehouse when the per-item toggle is on. It then reports
current/max, a percentage, and days-to-target from the burn rate. The
question it answers is "am I stocked up on Katoa".

**This PR is company-wide.** One row per material, summed across *every*
source the company owns:

- every planetary base inventory
- every rented warehouse, on planets and on CX stations
- every ship cargo hold
- every ship fuel tank

There are no targets and no per-location breakdown. The question it answers
is "how much of this do I own in total, and what is it worth". It adds
per-exchange valuation, which #236 does not have.

Both are multi-preset XIT screens and both follow the routing convention of
`XIT ACT`.

**Merge note:** if both land, whichever merges second needs a one-line
rebase. Both add a field after `actionPackages` in
`src/store/user-data.ts` and an interface block in
`src/store/user-data.types.d.ts`. Nothing else overlaps.


## Notes

- No `CHANGELOG.md` change, per `docs/contributing.md`.
- No new dependencies.
- Verified: `tsc --noEmit`, `eslint` and `vite build` all clean.