### PR TITLE
XIT ACT: Fix false abort on successful action feedback

### DIFF
--- a/src/features/XIT/ACT/runner/step-machine.ts
+++ b/src/features/XIT/ACT/runner/step-machine.ts
@@ -173,41 +173,25 @@ export class StepMachine {
 }
 
 async function waitActionFeedback(tile: PrunTile) {
-  let overlay = await $(tile.frame, C.ActionFeedback.overlay);
-  await waitActionProgress(overlay);
+  const overlay = await $(tile.frame, C.ActionFeedback.overlay);
   if (overlay.classList.contains(C.ActionConfirmationOverlay.container)) {
     const confirm = _$$(overlay, C.Button.btn)[1];
     if (confirm === undefined) {
       return 'Confirmation overlay is missing confirm button';
     }
     await clickElement(confirm);
-    overlay = await $(tile.frame, C.ActionFeedback.overlay);
-    await waitActionProgress(overlay);
   }
-  if (overlay.classList.contains(C.ActionFeedback.success)) {
-    await clickElement(overlay);
+  // The overlay is inserted before its state class is applied, so wait for a
+  // terminal state instead of sampling the classes once.
+  const outcome = await Promise.race([
+    $(tile.frame, C.ActionFeedback.error),
+    $(tile.frame, C.ActionFeedback.success),
+  ]);
+  if (outcome.classList.contains(C.ActionFeedback.success)) {
+    await clickElement(outcome);
     return;
   }
-  if (overlay.classList.contains(C.ActionFeedback.error)) {
-    const message = _$(overlay, C.ActionFeedback.message)?.textContent;
-    const dismiss = _$(overlay, C.ActionFeedback.dismiss)?.textContent;
-    return dismiss ? message?.replace(dismiss, '') : message;
-  }
-
-  return 'Unknown action feedback overlay';
-}
-
-async function waitActionProgress(overlay: HTMLElement) {
-  if (!overlay.classList.contains(C.ActionFeedback.progress)) {
-    return;
-  }
-  await new Promise<void>(resolve => {
-    const mutationObserver = new MutationObserver(() => {
-      if (!overlay.classList.contains(C.ActionFeedback.progress)) {
-        mutationObserver.disconnect();
-        resolve();
-      }
-    });
-    mutationObserver.observe(overlay, { attributes: true });
-  });
+  const message = _$(outcome, C.ActionFeedback.message)?.textContent;
+  const dismiss = _$(outcome, C.ActionFeedback.dismiss)?.textContent;
+  return dismiss ? message?.replace(dismiss, '') : message;
 }


### PR DESCRIPTION
## Problem

`waitActionFeedback` in `src/features/XIT/ACT/runner/step-machine.ts` waits for the feedback overlay element, calls `waitActionProgress(overlay)`, and then samples the `success` / `error` classes **once**.

The overlay is inserted before its state class is applied. When `waitActionFeedback` observes the overlay in that insertion-to-class gap, `waitActionProgress` returns immediately (there is no `progress` class yet to wait on) and neither `success` nor `error` is present, so the function falls through to `'Unknown action feedback overlay'`.

The step machine treats that string as a step failure: it logs the error and stops the whole action package. The CXPO / MTRA order was already submitted and can still succeed, so the package log and the game state disagree — the same step can end up recorded as failed while the order went through.

### This is not already fixed by af0a7c87

af0a7c87 ("Fix the "Unknown action feedback overlay" error when CX Buy places an order outside the price band") added `overlay = await $(tile.frame, C.ActionFeedback.overlay)` after the confirm click. That fixes a *stale element reference* — the code was still holding the removed confirmation overlay. It does not fix the sample-once read, for two reasons:

1. The re-query only exists inside the confirmation branch. Every step that gets no confirmation overlay — the common case — still reads the classes once and can fall through to `'Unknown action feedback overlay'`.
2. `$` is `waitElementByClassNameOrTag`, which returns `elements[0]` synchronously when the live collection is already non-empty. So the re-query resolves with the replacement overlay in the same insertion-to-class gap, `waitActionProgress` returns immediately because there is no `progress` class yet, and the three class checks all miss again.

In the harness below, the "confirmation overlay, then the gap" scenario runs against `main` *including* af0a7c87 and still returns `Unknown action feedback overlay`.

## Fix

Wait for a terminal `C.ActionFeedback.success` / `C.ActionFeedback.error` selector instead of sampling the classes once, and drop the now-unused `waitActionProgress`.

This is the pattern the codebase already uses for this overlay elsewhere:

- `src/infrastructure/prun-ui/utils/delete-exchange-order.ts` — `awaitActionOutcome`
- `src/features/basic/mtra-transfer-on-enter.ts`

So ACT now handles the overlay the same way as the rest of the extension rather than with its own class-sampling logic.

## Validation

- `pnpm compile && pnpm lint` — clean (matches `.github/workflows/lint.yml`).
- Behaviour was checked out-of-tree under jsdom against the real `select-dom` / `observe-html-collection` / `on-node-tree-mutation` helpers, driving the overlay through the game's insertion → `progress` → terminal sequence:

  | Scenario | before | after |
  | --- | --- | --- |
  | overlay inserted with no state class, later `success` | `Unknown action feedback overlay` | success, overlay dismissed |
  | overlay inserted with no state class, later `error` | `Unknown action feedback overlay` | the real error message |
  | overlay already has `progress`, later `success` | success | success (unchanged) |
  | overlay already has `progress`, later `error` | error message | error message (unchanged) |
  | confirmation overlay, then the gap, later `success` | `Unknown action feedback overlay` | success |

  A negative control confirms the harness can observe a hang, so those results are not vacuous.

Live in-game verification has not been done — I do not have a suitable environment for it. The behaviour above is from the harness only.

## Two things I deliberately did not do

1. **No timeout.** Waiting for a terminal state makes the wait unbounded if the game never produces one. I left it unbounded to match `awaitActionOutcome` and `mtra-transfer-on-enter`, and because a fixed timeout re-creates this exact bug whenever the server is slower than the limit. Happy to add a bound if you prefer one.

2. **No `CHANGELOG.md` entry**, per `docs/contributing.md`.

## Pre-existing, not touched

In the error branch, `message?.replace(dismiss, '')` can evaluate to `undefined` if the overlay has no message element. The caller treats a falsy return as success, so an errored action would be logged as successful. That hole exists on `main` today and is unrelated to the race, so I left it alone rather than widen this PR.

